### PR TITLE
Replaces bitfield bools with BOOL's, removes redundant unions

### DIFF
--- a/src/game/common/vector.h
+++ b/src/game/common/vector.h
@@ -53,15 +53,7 @@ protected:
     T *Vector;
     int VectorMax;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool IsAllocated : 1; // & 1
-        };
-        int m_vectorFlags;
-    };
+    BOOL IsAllocated : 1;
 #else
     bool IsAllocated;
 #endif

--- a/src/game/engine/abstract.h
+++ b/src/game/engine/abstract.h
@@ -62,15 +62,7 @@ protected:
     coord_t m_Coord;
     int m_Height;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_IsActive : 1; // 1
-        };
-        int Bitfield;
-    };
+    BOOL m_IsActive : 1; // 1
 #else
     bool m_IsActive;
 #endif

--- a/src/game/engine/aircraft.h
+++ b/src/game/engine/aircraft.h
@@ -43,19 +43,11 @@ private:
     FacingClass field_14A;
     void *field_14C;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_Bit1 : 1; // 1
-            bool m_Bit2 : 1; // 2
-            bool m_Bit4 : 1; // 4
-            bool m_Bit8 : 1; // 8
-            bool m_Bit16 : 1; // 16
-        };
-        int m_Bitfield;
-    };
+    BOOL m_Bit1 : 1; // 1
+    BOOL m_Bit2 : 1; // 2
+    BOOL m_Bit4 : 1; // 4
+    BOOL m_Bit8 : 1; // 8
+    BOOL m_Bit16 : 1; // 16
 #else
     bool m_Bit1;
     bool m_Bit2;

--- a/src/game/engine/aircrafttype.h
+++ b/src/game/engine/aircrafttype.h
@@ -75,18 +75,10 @@ public:
     
 private:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_Airplane : 1;
-            bool m_CustomRotor : 1;
-            bool m_Rotors : 1;
-            bool m_Transport : 1;
-        };
-        int Bitfield;
-    };
+    BOOL m_Airplane : 1;
+    BOOL m_CustomRotor : 1;
+    BOOL m_Rotors : 1;
+    BOOL m_Transport : 1;
 #else
     bool m_Airplane;
     bool m_CustomRotor;

--- a/src/game/engine/anim.h
+++ b/src/game/engine/anim.h
@@ -84,17 +84,9 @@ protected:
     HousesType m_Owner;
     unsigned char m_Loops;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_Bit1 : 1; // 1
-            bool m_Bit2 : 1; // 2
-            bool m_Invisible : 1; // 4
-        };
-        int m_Bitfield;
-    };
+    BOOL m_Bit1 : 1; // 1
+    BOOL m_Bit2 : 1; // 2
+    BOOL m_Invisible : 1; // 4
 #else
     bool m_Bit1; // to remove / delete?
     bool m_Bit2; // skip process once?

--- a/src/game/engine/animtype.h
+++ b/src/game/engine/animtype.h
@@ -66,23 +66,15 @@ public:
 
 private:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_Normalized : 1; // Should the animation speed be adjusted to appear at a consistent speed (def = false)?
-            bool m_Surface : 1; // Is this animation at ground level (def = false)?
-            bool m_Translucent : 1; // Is this animation translucent in appearence (def = false)?
-            bool m_Bit_8 : 1; // AltPalette = Does it use an alternate drawing palette (def = false)?
-            bool m_Flamer : 1; // Flamer = Does this animation leave flames after it is gone [e.g., napalm] (def = false)?
-            bool m_Scorch : 1; // Does this animation scorch the ground [e.g., napalm does this] (def = false)?
-            bool m_Crater : 1; // Does this form a crater [e.g., artillery does this] (def = false)?
-            bool m_Sticky : 1; // Sticky = Animation sticks to unit in cell (def = false)? C&C uses this for BOAT
-            bool m_Theater : 1; // Does it have theater specific imagery (def = false)?
-        };
-        int Bitfield;
-    };
+    BOOL m_Normalized : 1;
+    BOOL m_Surface : 1;
+    BOOL m_Translucent : 1;
+    BOOL m_Bit_8 : 1;
+    BOOL m_Flamer : 1;
+    BOOL m_Scorch : 1;
+    BOOL m_Crater : 1;
+    BOOL m_Sticky : 1;
+    BOOL m_Theater : 1;
 #else
     bool m_Normalized; // Should the animation speed be regulated/adjusted to appear at a consistent speed (def = false)?
     bool m_Surface; // Is this animation at ground level (def = false)?

--- a/src/game/engine/building.h
+++ b/src/game/engine/building.h
@@ -44,19 +44,11 @@ private:
     GamePtr<FactoryClass> m_Factory;
     HousesType m_field_D5;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_Bit1 : 1; // 1
-            bool m_Bit2 : 1; // 2
-            bool m_Bit4 : 1; // 4
-            bool m_Bit8 : 1; // 8
-            bool m_Bit16 : 1; // 16
-    };
-        int m_Bitfield;
-};
+    BOOL m_Bit1 : 1; // 1
+    BOOL m_Bit2 : 1; // 2
+    BOOL m_Bit4 : 1; // 4
+    BOOL m_Bit8 : 1; // 8
+    BOOL m_Bit16 : 1; // 16
 #else
     bool m_Bit1;
     bool m_Bit2;

--- a/src/game/engine/buildingtype.h
+++ b/src/game/engine/buildingtype.h
@@ -234,23 +234,15 @@ public:
     
 private:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_BaseNormal : 1;
-            bool m_Fake : 1;
-            bool m_Bib : 1;
-            bool m_Wall : 1;
-            bool m_SimpleDamage : 1;
-            bool m_Capturable : 1;
-            bool m_Normalized : 1;
-            bool m_Powered : 1;
-            bool m_Unsellable : 1;
-        };
-        int Bitfield;
-    };
+    BOOL m_BaseNormal : 1; // & 1Considered for building adjacency checks (def = true)?
+    BOOL m_Fake : 1; // & 2 Is this a fake structure (def = false)?
+    BOOL m_Bib : 1; // & 4 Does the building have a bib built in (def = false)?
+    BOOL m_Wall : 1; // & 8 Is this a wall type structure [special rules apply] (def = false)?
+    BOOL m_SimpleDamage : 1; // & 16 Does building have simple damage imagery (def = true)?
+    BOOL m_Capturable : 1; // & 32 Can this building be infiltrated by a spy/thief/engineer (def = false)?
+    BOOL m_Normalized : 1; // & 64 Is nimation speed adjusted for a consistent speed (def = false)?
+    BOOL m_Powered : 1; // & 128 Does it require power to function (def = false)?
+    BOOL m_Unsellable : 1; // & 1 Cannot sell this building (even if it can be built) (def = false)?
 #else
     bool m_BaseNormal; // Considered for building adjacency checks (def = true)?
     bool m_Fake; // Is this a fake structure (def = false)?

--- a/src/game/engine/bullettype.h
+++ b/src/game/engine/bullettype.h
@@ -91,32 +91,24 @@ public:
 
 private:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool High : 1; // Can it fly over walls?
-            bool Shadow : 1; // If High, does this bullet need to have a shadow drawn?
-            bool Arcing : 1; // Does it have a ballistic trajectory?
-            bool Dropping : 1; // Does it fall from a starting height?
-            bool Inviso : 1; // Is the projectile invisible as it travels?
-            bool Proximity : 1; // Does it blow up when near its target?
-            bool Animates : 1; // Does it animate [this means smoke puffs]?
-            bool Ranged : 1; // Can it run out of fuel?
-            bool Rotates : 1; // Does the projectile have rotation specific imagery?
-            bool Inaccurate : 1; // Is it inherently inaccurate?
-            bool Translucent : 1; // Are translucent colors used in artwork?
-            bool AntiAir : 1; // Can this weapon fire upon flying aircraft?
-            bool AntiGround : 1; // Can this weapon fire upon ground objects?
-            bool AntiSubWarfare : 1; // Is this an Anti-Submarine-Warfare projectile?
-            bool Degenerates : 1; // Does the bullet strength weaken as it travels?
-            bool UnderWater : 1; // Does the projectile travel under water?
-            bool Parachuted : 1; // Equipped with a parachute for dropping from plane (def = false)?
-            bool Gigundo : 1; // Is the projectile larger than normal?
-        };
-        int Bitfield;
-    };
+    BOOL High : 1; // Can it fly over walls?
+    BOOL Shadow : 1; // If High, does this bullet need to have a shadow drawn?
+    BOOL Arcing : 1; // Does it have a ballistic trajectory?
+    BOOL Dropping : 1; // Does it fall from a starting height?
+    BOOL Inviso : 1; // Is the projectile invisible as it travels?
+    BOOL Proximity : 1; // Does it blow up when near its target?
+    BOOL Animates : 1; // Does it animate [this means smoke puffs]?
+    BOOL Ranged : 1; // Can it run out of fuel?
+    BOOL Rotates : 1; // Does the projectile have rotation specific imagery?
+    BOOL Inaccurate : 1; // Is it inherently inaccurate?
+    BOOL Translucent : 1; // Are translucent colors used in artwork?
+    BOOL AntiAir : 1; // Can this weapon fire upon flying aircraft?
+    BOOL AntiGround : 1; // Can this weapon fire upon ground objects?
+    BOOL AntiSubWarfare : 1; // Is this an Anti-Submarine-Warfare projectile?
+    BOOL Degenerates : 1; // Does the bullet strength weaken as it travels?
+    BOOL UnderWater : 1; // Does the projectile travel under water?
+    BOOL Parachuted : 1; // Equipped with a parachute for dropping from plane (def = false)?
+    BOOL Gigundo : 1; // Is the projectile larger than normal?
 #else
     bool High; // Can it fly over walls?
     bool Shadow; // If High, does this bullet need to have a shadow drawn?

--- a/src/game/engine/cell.h
+++ b/src/game/engine/cell.h
@@ -186,22 +186,14 @@ private:
     cell_t CellNumber;
 
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool Bit1 : 1; // 1
-            bool PlacementCheck : 1; // 2
-            bool Visible : 1; // 4 // Is this cell at least partly visible due ot being next to a revealed or visible cell.
-            bool Revealed : 1; // 8 // Is this cell fully revealed and thus has no shroud at all.
-            bool Bit16 : 1; // 16    //Could be HasWaypoint?  HasCellTag?
-            bool Bit32 : 1; // 32    //MarkedOnRadar? IsWaypoint in C&C ? does the radar cursor cover this cell?
-            bool HasFlag : 1; // 64
-            bool Bit128 : 1; // 128 // HasFlag in C&C relates to Region here. Look like it marks a cell to advance shroud.
-        };
-        int Bitfield;
-    };
+    BOOL Bit1 : 1; // 1
+    BOOL PlacementCheck : 1; // 2
+    BOOL Visible : 1; // 4 // Is this cell at least partly visible due ot being next to a revealed or visible cell.
+    BOOL Revealed : 1; // 8 // Is this cell fully revealed and thus has no shroud at all.
+    BOOL Bit16 : 1; // 16    //Could be HasWaypoint?  HasCellTag?
+    BOOL Bit32 : 1; // 32    //MarkedOnRadar? IsWaypoint in C&C ? does the radar cursor cover this cell?
+    BOOL HasFlag : 1; // 64
+    BOOL Bit128 : 1; // 128 // HasFlag in C&C relates to Region here. Look like it marks a cell to advance shroud.
 #else
     bool Bit1;
     bool PlacementCheck;

--- a/src/game/engine/difficulty.h
+++ b/src/game/engine/difficulty.h
@@ -46,17 +46,9 @@ struct DifficultyClass
     fixed_t RepairDelay; // Average delay (minutes) between initiating building repair.
     fixed_t BuildDelay; // Average delay (minutes) between initiating construction.
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool BuildSlowdown : 1; // & 1 Should the computer build slower than the player.
-            bool DestroyWalls : 1; // & 2 Allow scanning for nearby enemy walls and destroy them.
-            bool ContentScan : 1; // & 4 Should the contents of a transport be considered when picking best target?
-        };
-        int Bitfield;
-    };
+    BOOL BuildSlowdown : 1; // & 1 Should the computer build slower than the player.
+    BOOL DestroyWalls : 1; // & 2 Allow scanning for nearby enemy walls and destroy them.
+    BOOL ContentScan : 1; // & 4 Should the contents of a transport be considered when picking best target?
 #else
     bool BuildSlowdown; // Should the computer build slower than the player.
     bool DestroyWalls; // Allow scanning for nearby enemy walls and destroy them.

--- a/src/game/engine/display.h
+++ b/src/game/engine/display.h
@@ -143,20 +143,12 @@ protected:
     int TacOffsetY;
     coord_t DisplayNewPos;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool DisplayToRedraw : 1; // 1
-            bool DisplayRepairMode : 1; // 2
-            bool DisplaySellMode : 1; // 4
-            bool DisplayBit8 : 1; // 8 This is Bit32 in SS. passes proximity check/can place?
-            bool DisplayBit16 : 1; // 16
-            bool RedrawShadow : 1; // 32 this is Bit128 in SS
-        };
-        int Bitfield;
-    };
+    BOOL DisplayToRedraw : 1; // 1
+    BOOL DisplayRepairMode : 1; // 2
+    BOOL DisplaySellMode : 1; // 4
+    BOOL DisplayBit8 : 1; // 8 This is Bit32 in SS. passes proximity check/can place?
+    BOOL DisplayBit16 : 1; // 16
+    BOOL RedrawShadow : 1; // 32 this is Bit128 in SS
 #else
     bool DisplayToRedraw;
     bool DisplayRepairMode;

--- a/src/game/engine/door.h
+++ b/src/game/engine/door.h
@@ -57,15 +57,7 @@ private:
     int8_t Stage; // Number of stages between end states (open or closed).
     DoorState State; // Current processing state.
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool StageComplete : 1;
-        };
-        int Bitfield; // This shouldn't be used in the code.
-    };
+    BOOL StageComplete : 1;
 #else
     bool StageComplete;
 #endif

--- a/src/game/engine/drive.h
+++ b/src/game/engine/drive.h
@@ -66,18 +66,10 @@ public:
 
 protected:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_IsHarvesting : 1; // 1
-            bool m_Teleported : 1; // 2
-            bool m_Bit_4 : 1; // 4
-            bool m_Bit_8 : 1; // 8
-        };
-        int m_Bitfield;
-    };
+    BOOL m_IsHarvesting : 1; // 1
+    BOOL m_Teleported : 1; // 2
+    BOOL m_Bit_4 : 1; // 4
+    BOOL m_Bit_8 : 1; // 8
 #else
     bool m_IsHarvesting;
     bool m_Teleported;

--- a/src/game/engine/factory.h
+++ b/src/game/engine/factory.h
@@ -72,17 +72,9 @@ private:
     RTTIType m_RTTI;
     int m_HeapID;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_IsActive : 1; // 1
-            bool m_IsSuspended : 1; // 2
-            bool m_IsDifferent : 1; // 4
-        };
-        int m_Bitfield;
-    };
+    BOOL m_IsActive : 1; // 1
+    BOOL m_IsSuspended : 1; // 2
+    BOOL m_IsDifferent : 1; // 4
 #else
     bool m_IsActive;
     bool m_IsSuspended;

--- a/src/game/engine/flasher.h
+++ b/src/game/engine/flasher.h
@@ -41,20 +41,10 @@ public:
 
 private:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-#pragma pack(push, 1)
-        struct
-        {
-            int8_t Frames : 7;
-            bool Flashed : 1;
-        };
-#pragma pack(pop)
-        int Bitfield; // This shouldn't be used in the code.
-    };
+    unsigned int Frames : 7;
+    BOOL Flashed : 1;
 #else
-    int Frames; // Number of frames to flash for.
+    unsigned int Frames; // Number of frames to flash for.
     bool Flashed; // Is current frame a flash frame?
 #endif
 };

--- a/src/game/engine/foot.h
+++ b/src/game/engine/foot.h
@@ -123,27 +123,19 @@ public:
 
 protected:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_Bit1_1 : 1; // 1
-            bool m_Initiated : 1; // 2
-            bool m_Bit1_4 : 1; // 4
-            bool m_ToLook : 1; // 8
-            bool m_Deploying : 1; // 16
-            bool m_Firing : 1; // 32
-            bool m_Rotating : 1; // 64
-            bool m_Moving : 1; // 128
-            bool m_Bit2_1 : 1; // 1
-            bool m_InFormation : 1; // 2
-            bool m_Bit2_4 : 1; // 4
-            bool m_ToScatter : 1; // 8
-            bool m_Bit2_16 : 1; // 16
-        };
-        int m_Bitfield;
-    };
+    BOOL m_Bit1_1 : 1; // 1
+    BOOL m_Initiated : 1; // 2
+    BOOL m_Bit1_4 : 1; // 4
+    BOOL m_ToLook : 1; // 8
+    BOOL m_Deploying : 1; // 16
+    BOOL m_Firing : 1; // 32
+    BOOL m_Rotating : 1; // 64
+    BOOL m_Moving : 1; // 128
+    BOOL m_Bit2_1 : 1; // 1
+    BOOL m_InFormation : 1; // 2
+    BOOL m_Bit2_4 : 1; // 4
+    BOOL m_ToScatter : 1; // 8
+    BOOL m_Bit2_16 : 1; // 16
 #else
     bool m_Bit1_1;
     bool m_Initiated;

--- a/src/game/engine/gameevent.h
+++ b/src/game/engine/gameevent.h
@@ -223,17 +223,9 @@ private:
     GameEventType m_Type; // The type for this object (def = EVENT_NONE).
 
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            unsigned int m_EventFrame : 26; //
-            unsigned int m_HouseID : 5; //
-            BOOL m_IsExecuted : 1; //
-        };
-        int m_Bitfield;
-    };
+    unsigned int m_EventFrame : 26; //
+    unsigned int m_HouseID : 5; //
+    BOOL m_IsExecuted : 1; //
 #else
     unsigned int m_EventFrame; // The frame this event was created on.
     unsigned int m_HouseID; // The id of the house that triggered this event.

--- a/src/game/engine/gameini.h
+++ b/src/game/engine/gameini.h
@@ -175,15 +175,7 @@ public:
 
 private:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool DigestValid : 1; // & 1
-        };
-        int Bitfield;
-    };
+    BOOL DigestValid : 1; // & 1
 #else
     bool DigestValid;
 #endif

--- a/src/game/engine/gmouse.h
+++ b/src/game/engine/gmouse.h
@@ -56,15 +56,7 @@ public:
 
 protected:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_MouseInRadar : 1; // 1 Is the mouse in the radar map?
-        };
-        int Bitfield;
-    };
+    BOOL m_MouseInRadar : 1; // 1 Is the mouse in the radar map?
 #else
     bool m_MouseInRadar; // Is the mouse in the radar map?
 #endif

--- a/src/game/engine/ground.h
+++ b/src/game/engine/ground.h
@@ -72,15 +72,7 @@ public:
     fixed_t Speeds[SPEED_COUNT];
 
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool Buildable : 1; // & 1
-        };
-        int Bitfield;
-    };
+    BOOL Buildable : 1; // & 1
 #else
     bool Buildable; // Can buildings be built upon this terrain [def = false]?
 #endif

--- a/src/game/engine/help.h
+++ b/src/game/engine/help.h
@@ -56,15 +56,7 @@ protected:
     int HelpUnkInt2;
     int HelpUnkInt3;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool HelpForceDraw : 1; // 1
-        };
-        int Bitfield;
-    };
+    BOOL HelpForceDraw : 1; // 1
 #else
     bool HelpForceDraw;
 #endif

--- a/src/game/engine/house.h
+++ b/src/game/engine/house.h
@@ -222,42 +222,34 @@ private:
     HousesType m_ActsLike;
 
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_IsActive : 1; // 1
-            bool m_IsHuman : 1; // 2
-            bool m_PlayerControl : 1; // 4
-            bool m_Production : 1; // 8
-            bool m_Autocreate : 1; // 16
-            bool m_AutoBaseAI : 1; // 32
-            bool m_Discovered : 1; // 64
-            bool m_MaxCapacity : 1; // 128
+    BOOL m_IsActive : 1; // 1
+    BOOL m_IsHuman : 1; // 2
+    BOOL m_PlayerControl : 1; // 4
+    BOOL m_Production : 1; // 8
+    BOOL m_Autocreate : 1; // 16
+    BOOL m_AutoBaseAI : 1; // 32
+    BOOL m_Discovered : 1; // 64
+    BOOL m_MaxCapacity : 1; // 128
 
-            bool m_Defeated : 1; // 1
-            bool m_ToDie : 1; // 2
-            bool m_ToWin : 1; // 4
-            bool m_ToLose : 1; // 8
-            bool m_CivEvac : 1; // 16
-            bool m_RecalcNeeded : 1; // 32
-            bool m_Visionary : 1; // 64
-            bool m_OreShort : 1; // 128
+    BOOL m_Defeated : 1; // 1
+    BOOL m_ToDie : 1; // 2
+    BOOL m_ToWin : 1; // 4
+    BOOL m_ToLose : 1; // 8
+    BOOL m_CivEvac : 1; // 16
+    BOOL m_RecalcNeeded : 1; // 32
+    BOOL m_Visionary : 1; // 64
+    BOOL m_OreShort : 1; // 128
 
-            bool m_Spied : 1; // 1
-            bool m_Infiltrated : 1; // 2
-            bool m_Repairing : 1; // 4
-            bool m_MapIsClear : 1; // 8
-            bool m_BuiltSomething : 1; // 16
-            bool m_Resigned : 1; // 32
-            bool m_GaveUp : 1; // 64
-            bool m_Paranoid : 1; // 128
+    BOOL m_Spied : 1; // 1
+    BOOL m_Infiltrated : 1; // 2
+    BOOL m_Repairing : 1; // 4
+    BOOL m_MapIsClear : 1; // 8
+    BOOL m_BuiltSomething : 1; // 16
+    BOOL m_Resigned : 1; // 32
+    BOOL m_GaveUp : 1; // 64
+    BOOL m_Paranoid : 1; // 128
 
-            bool m_AllToLook : 1; // 1
-        };
-        int m_Bitfield;
-    };
+    BOOL m_AllToLook : 1; // 1
 #else
     bool m_IsActive; // Is this object allocated and active for use? (def = false)
                      // NOTE: This should be set to true on class creation.

--- a/src/game/engine/infantry.h
+++ b/src/game/engine/infantry.h
@@ -53,19 +53,11 @@ private:
     DoType m_Doing;
     TCountDownTimerClass<FrameTimerClass> m_StokeTimer;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_Technician : 1; // 1
-            bool m_Stoked : 1; // 2
-            bool m_Prone : 1; // 4
-            bool m_Bit8 : 1; // 8
-            bool m_Bit16 : 1; // 16
-        };
-        int m_Bitfield;
-    };
+    BOOL m_Technician : 1; // 1
+    BOOL m_Stoked : 1; // 2
+    BOOL m_Prone : 1; // 4
+    BOOL m_Bit8 : 1; // 8
+    BOOL m_Bit16 : 1; // 16
 #else
     bool m_Technician;
     bool m_Stoked;

--- a/src/game/engine/infantrytype.h
+++ b/src/game/engine/infantrytype.h
@@ -133,22 +133,14 @@ public:
 
 private:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_FemaleVoice : 1; // & 1 Uses the civilian female voice (def = false)?
-            bool m_IsCrawler : 1; // & 2 Does this infantry crawl (go prone) when under fire (def = false)?
-            bool m_IsInfiltrator : 1; // & 4 Can it enter a building like a spy or thief (def = false)?
-            bool m_IsFraidycat : 1; // & 8 Is it inherently afraid and will panic easily (def = false)?
-            bool m_IsCivilian : 1; // & 16 Counts a civilian for evac and kill tracking (def = false)?
-            bool m_HasC4 : 1; // & 32 Equipped with explosives [presumes Infiltrate is also true] (def = false)?
-            bool m_IsCanine : 1; // & 64 Should special case dog logic be applied to this (def = false)?
-            bool m_HasAltRemap : 1; // & 128
-        };
-        int Bitfield;
-    };
+    BOOL m_FemaleVoice : 1; // & 1 Uses the civilian female voice (def = false)?
+    BOOL m_IsCrawler : 1; // & 2 Does this infantry crawl (go prone) when under fire (def = false)?
+    BOOL m_IsInfiltrator : 1; // & 4 Can it enter a building like a spy or thief (def = false)?
+    BOOL m_IsFraidycat : 1; // & 8 Is it inherently afraid and will panic easily (def = false)?
+    BOOL m_IsCivilian : 1; // & 16 Counts a civilian for evac and kill tracking (def = false)?
+    BOOL m_HasC4 : 1; // & 32 Equipped with explosives [presumes Infiltrate is also true] (def = false)?
+    BOOL m_IsCanine : 1; // & 64 Should special case dog logic be applied to this (def = false)?
+    BOOL m_HasAltRemap : 1; // & 128
 #else
     bool m_FemaleVoice; // Uses the civilian female voice (def = false)?
     bool m_IsCrawler; // Does this infantry crawl (go prone) when under fire (def = false)?

--- a/src/game/engine/missioncontrol.h
+++ b/src/game/engine/missioncontrol.h
@@ -37,20 +37,12 @@ public:
 private:
     MissionType Mission; // The mission we control (def = MISSION_NONE).
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-                         // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool NoThreat : 1; // & 1 Is its weapons disabled and thus ignored as a potential target until fired upon (def = false)?
-            bool Zombie : 1; // & 2 Is forced to sit there like a zombie and never recovers (def = false)?
-            bool Recruitable : 1; // & 4 Can it be recruited into a team or base defense (def = true)?
-            bool Paralyzed : 1;    // & 8 Is the object frozen in place but can still fire and function (def = false)?
-            bool Retaliate : 1; // & 16 Is allowed to retaliate while on this mission (def = true)?
-            bool Scatter : 1; // & 32 Is allowed to scatter from threats (def = true)?
-        };
-        int Bitfield;
-    };
+    BOOL NoThreat : 1;
+    BOOL Zombie : 1;
+    BOOL Recruitable : 1;
+    BOOL Paralyzed : 1;
+    BOOL Retaliate : 1;
+    BOOL Scatter : 1;
 #else
     bool NoThreat; // Is its weapons disabled and thus ignored as a potential target until fired upon (def = false)?
     bool Zombie; // Is forced to sit there like a zombie and never recovers (def = false)?

--- a/src/game/engine/msglist.h
+++ b/src/game/engine/msglist.h
@@ -74,17 +74,9 @@ private:
     int MaxChars;
     int MessageHeight;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool Concatenate : 1; // & 1
-            bool Editing : 1; // & 2
-            bool EditAsMessage : 1; // & 4
-        };
-        int m_listFlags;
-    };
+    BOOL Concatenate : 1; // & 1
+    BOOL Editing : 1; // & 2
+    BOOL EditAsMessage : 1; // & 4
 #else
     bool Concatenate; // 1
     bool Editing; // 2

--- a/src/game/engine/object.h
+++ b/src/game/engine/object.h
@@ -121,22 +121,14 @@ public:
 
 protected:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_IsDown : 1; // 1
-            bool m_ToDamage : 1; // 2
-            bool m_ToDisplay : 1; // 4
-            bool m_InLimbo : 1; // 8 Is this object in limbo [state of nothing, thus not processed per frame tick]?
-            bool m_Selected : 1; // 16 Has this object been selected by the player?
-            bool m_AnimAttached : 1; // 32
-            bool m_IsFalling : 1; // 64 Is this object falling from a height [as a paradropped object]?
-            bool m_OBit1_128 : 1; // 128
-        };
-        int m_Bitfield;
-    };
+    BOOL m_IsDown : 1; // 1
+    BOOL m_ToDamage : 1; // 2
+    BOOL m_ToDisplay : 1; // 4
+    BOOL m_InLimbo : 1; // 8
+    BOOL m_Selected : 1; // 16
+    BOOL m_AnimAttached : 1; // 32
+    BOOL m_IsFalling : 1; // 64
+    BOOL m_OBit1_128 : 1; // 128
 #else
     bool m_IsDown;
     bool m_ToDamage;

--- a/src/game/engine/objecttype.h
+++ b/src/game/engine/objecttype.h
@@ -74,22 +74,14 @@ protected:
 protected:
     char ImageName[256];
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool Crushable : 1; // & 1 Can it be crushed by a heavy tracked vehicle (def = false)?
-            bool RadarInvisible : 1; // & 2 Is it invisible on radar maps (def = false)? unused in RA?
-            bool Selectable : 1; // & 4 Can this object be selected by the player (def = true)?
-            bool LegalTarget : 1; // & 8 Is this allowed to be a combat target (def = true)?
-            bool Insignificant : 1; // & 16 Will this object not be announced when destroyed (def = false)?
-            bool Immune : 1; // & 32 Is this object immune to damage (def = false)?
-            bool Bit64 : 1; // & 64 TODO: Related to logical or animate?
-            bool Bit128 : 1; // & 128 TODO: Related to logical or animate?
-        };
-        int Bitfield;
-    };
+    BOOL Crushable : 1; // & 1
+    BOOL RadarInvisible : 1; // & 2
+    BOOL Selectable : 1; // & 4
+    BOOL LegalTarget : 1; // & 8
+    BOOL Insignificant : 1; // & 16
+    BOOL Immune : 1; // & 32
+    BOOL Bit64 : 1; // & 64
+    BOOL Bit128 : 1; // & 128
 #else
     bool Crushable; // Can it be crushed by a heavy tracked vehicle (def = false)?
     bool RadarInvisible; // Is it invisible on radar maps (def = false)? unused in RA?

--- a/src/game/engine/options.h
+++ b/src/game/engine/options.h
@@ -196,23 +196,15 @@ private:
     fixed_t Saturation;
     fixed_t Contrast;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool AutoScroll : 1; // & 1
-            bool ScoreRepeats : 1; // & 2
-            bool ScoreShuffles : 1; // & 4
-            bool PaletteScroll : 1; // & 8
-            bool FreeScrolling : 1; // & 16 Chronoshift option.
-            bool DeathAnnounce : 1; // & 32 Chronoshift option.
-            bool AllowSidebarToggle : 1; // & 64 Chronoshift option.
-            bool CounterstrikeEnabled : 1; // & 128 Chronoshift option.
-            bool AftermathEnabled : 1; // & 256 Chronoshift option.
-        };
-        int Bitfield;
-    };
+    BOOL AutoScroll : 1; // & 1
+    BOOL ScoreRepeats : 1; // & 2
+    BOOL ScoreShuffles : 1; // & 4
+    BOOL PaletteScroll : 1; // & 8
+    BOOL FreeScrolling : 1; // & 16 Chronoshift option.
+    BOOL DeathAnnounce : 1; // & 32 Chronoshift option.
+    BOOL AllowSidebarToggle : 1; // & 64 Chronoshift option.
+    BOOL CounterstrikeEnabled : 1; // & 128 Chronoshift option.
+    BOOL AftermathEnabled : 1; // & 256 Chronoshift option.
 #else
     bool AutoScroll;
     bool ScoreRepeats;

--- a/src/game/engine/overlaytype.h
+++ b/src/game/engine/overlaytype.h
@@ -125,30 +125,21 @@ private:
     int DamageLevels; // think how many damage stages walls have for example.
     int OverlayStrength;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool Theater : 1; // 1
-            bool Wall : 1; // 2
-            bool High : 1; // 4
-            bool Ore : 1; // 8
-            bool Boolean16 : 1; // 16        //this is checked in Explosion_Damage() if warhead has wall or wood to see if
-                                // destroyed.
-            bool Crate : 1; // 32
-            bool RadarVisible : 1; // 64
-        };
-        int Bitfield;
-    };
+    BOOL Theater : 1; // 1
+    BOOL Wall : 1; // 2
+    BOOL High : 1; // 4
+    BOOL Ore : 1; // 8
+    BOOL Boolean16 : 1; // 16
+    BOOL Crate : 1; // 32
+    BOOL RadarVisible : 1; // 64
 #else
-    bool Theater; // 1
-    bool Wall; // 2
-    bool High; // 4
-    bool Ore; // 8
-    bool Boolean16; // 16        //this is checked in Explosion_Damage() if warhead has wall or wood to see if destroyed.
-    bool Crate; // 32
-    bool RadarVisible; // 64
+    bool Theater;
+    bool Wall;
+    bool High;
+    bool Ore;
+    bool Boolean16; // TODO: this is checked in Explosion_Damage() if warhead has wall or wood to see if destroyed.
+    bool Crate;
+    bool RadarVisible;
 #endif
 };
 

--- a/src/game/engine/power.h
+++ b/src/game/engine/power.h
@@ -54,15 +54,7 @@ public:
 
 protected:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool PowerToRedraw : 1; // 1
-        };
-        int Bitfield;
-    };
+    BOOL PowerToRedraw : 1; // 1
 #else
     bool PowerToRedraw;
 #endif

--- a/src/game/engine/radar.h
+++ b/src/game/engine/radar.h
@@ -122,48 +122,40 @@ protected:
     int field_CAC;
 
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool RadarToRedraw : 1; // 1
-            bool RadarCursorRedraw : 1; // 2
-            bool RadarExists : 1; // 4 Low power?
-            bool RadarActive : 1; // 8 enabling from power off?
-            bool RadarActivating : 1; // 16 //RadarActivating?
-            bool RadarDeactivating : 1; // 32 //RadarDeactivating?
-            bool RadarJammed : 1; // 64
-            bool RadarPulseActive : 1; // 128 this is also set when the radar is being jammed? see HouseClass::AI
-            bool RadarZoomed : 1; // 1 Zoomed?
-            bool RadarDrawNames : 1; // 2
-            bool RadarDrawSpiedInfo : 1; // 4 tomsons said this does some type of redraw?
-            bool RadarBit2_8 : 1; // 8
-            bool RadarBit2_16 : 1; // 16
-            bool RadarBit2_32 : 1; // 32
-            bool RadarBit2_64 : 1; // 64
-            bool RadarBit2_128 : 1; // 128
-        };
-        int Bitfield;
-    };
+    BOOL RadarToRedraw : 1; // 1
+    BOOL RadarCursorRedraw : 1; // 2
+    BOOL RadarExists : 1; // 4
+    BOOL RadarActive : 1; // 8
+    BOOL RadarActivating : 1; // 16
+    BOOL RadarDeactivating : 1; // 32
+    BOOL RadarJammed : 1; // 64
+    BOOL RadarPulseActive : 1; // 128
+
+    BOOL RadarZoomed : 1; // 1
+    BOOL RadarDrawNames : 1; // 2
+    BOOL RadarDrawSpiedInfo : 1; // 4
+    BOOL RadarBit2_8 : 1; // 8
+    BOOL RadarBit2_16 : 1; // 16
+    BOOL RadarBit2_32 : 1; // 32
+    BOOL RadarBit2_64 : 1; // 64
+    BOOL RadarBit2_128 : 1; // 128
 #else
-    // bitfield 0xCB0
-    bool RadarToRedraw; // 1
-    bool RadarCursorRedraw; // 2
-    bool RadarExists; // 4 Low power?
-    bool RadarActive; // enabling from power off?
-    bool RadarActivating; // 16 //RadarActivating?
-    bool RadarDeactivating; // 32 //RadarDeactivating?
-    bool RadarJammed; // 64
-    bool RadarPulseActive; // 128 this is also set when the radar is being jammed? see HouseClass::AI
-    bool RadarZoomed; // 1 Zoomed?
-    bool RadarDrawNames; // 2
-    bool RadarDrawSpiedInfo; // 4 tomsons said this does some type of redraw?
-    bool RadarBit2_8; //
-    bool RadarBit2_16; // 16
-    bool RadarBit2_32; // 32
-    bool RadarBit2_64; // 64
-    bool RadarBit2_128; // 128
+    bool RadarToRedraw;
+    bool RadarCursorRedraw;
+    bool RadarExists;
+    bool RadarActive;
+    bool RadarActivating;
+    bool RadarDeactivating;
+    bool RadarJammed;
+    bool RadarPulseActive;
+    bool RadarZoomed;
+    bool RadarDrawNames;
+    bool RadarDrawSpiedInfo;
+    bool RadarBit2_8;
+    bool RadarBit2_16;
+    bool RadarBit2_32;
+    bool RadarBit2_64;
+    bool RadarBit2_128;
 #endif
     int RadarPulseFrame;
     int RadarCursorFrame; // bytes relating to region box focus in animation.

--- a/src/game/engine/rules.h
+++ b/src/game/engine/rules.h
@@ -314,20 +314,12 @@ private:
     int MPlayerMoney;
     int MPlayerMaxMoney;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool MPlayerShadowGrow : 1; // 1
-            bool MPlayerBases : 1; // 2
-            bool MPlayerOreGrows : 1; // 4
-            bool MPlayerCrates : 1; // 8
-            bool MPlayerAIPlayers : 1; // 16
-            bool MPlayerCaptureTheFlag : 1; // 32
-        };
-        int MPBitfield;
-    };
+    BOOL MPlayerShadowGrow : 1; // 1
+    BOOL MPlayerBases : 1; // 2
+    BOOL MPlayerOreGrows : 1; // 4
+    BOOL MPlayerCrates : 1; // 8
+    BOOL MPlayerAIPlayers : 1; // 16
+    BOOL MPlayerCaptureTheFlag : 1; // 32
 #else
     bool MPlayerShadowGrow; // 1
     bool MPlayerBases; // 2
@@ -353,55 +345,49 @@ private:
     int AtomDamage;
     DifficultyClass Difficulties[3];
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool Paranoid : 1; // 1
-            bool CurleyShuffle : 1; // 2
-            bool FlashLowPower : 1; // 4
-            bool CompEasyBonus : 1; // 8
-            bool FineDiffControl : 1; // 16
-            bool OreExplosive : 1; // 32
-            bool EnemyHealth : 1; // 64
-            bool MCVUndeploy : 1; // 128
-            bool AllyReveal : 1; // 1
-            bool SeparateAircraft : 1; // 2
-            bool TreeTargeting : 1; // 4
-            bool MineAware : 1; // 8
-            bool OreGrows : 1; // 16
-            bool OreSpreads : 1; // 32
-            bool NamedCivilians : 1; // 64
-            bool PlayerAutoCrush : 1; // 128
-            bool PlayerReturnFire : 1; // 1
-            bool PlayerScatter : 1; // 2
-            bool ChronoKillCargo : 1; // 4
-            bool SecretUnitsEnabled : 1;
-            bool NewUnitsEnabled : 1;
-        };
-        int Bitfield;
-    };
+    BOOL Paranoid : 1; // 1
+    BOOL CurleyShuffle : 1; // 2
+    BOOL FlashLowPower : 1; // 4
+    BOOL CompEasyBonus : 1; // 8
+    BOOL FineDiffControl : 1; // 16
+    BOOL OreExplosive : 1; // 32
+    BOOL EnemyHealth : 1; // 64
+    BOOL MCVUndeploy : 1; // 128
+
+    BOOL AllyReveal : 1; // 1
+    BOOL SeparateAircraft : 1; // 2
+    BOOL TreeTargeting : 1; // 4
+    BOOL MineAware : 1; // 8
+    BOOL OreGrows : 1; // 16
+    BOOL OreSpreads : 1; // 32
+    BOOL NamedCivilians : 1; // 64
+    BOOL PlayerAutoCrush : 1; // 128
+
+    BOOL PlayerReturnFire : 1; // 1
+    BOOL PlayerScatter : 1; // 2
+    BOOL ChronoKillCargo : 1; // 4
+    BOOL SecretUnitsEnabled : 1; // new in Chronoshift
+    BOOL NewUnitsEnabled : 1; // new in Chronoshift
 #else
-    bool Paranoid; // 1
-    bool CurleyShuffle; // 2
-    bool FlashLowPower; // 4
-    bool CompEasyBonus; // 8
-    bool FineDiffControl; // 16
-    bool OreExplosive; // 32
-    bool EnemyHealth; // 64
-    bool MCVUndeploy; // 128
-    bool AllyReveal; // 1
-    bool SeparateAircraft; // 2
-    bool TreeTargeting; // 4
-    bool MineAware; // 8
-    bool OreGrows; // 16
-    bool OreSpreads; // 32
-    bool NamedCivilians; // 64
-    bool PlayerAutoCrush; // 128
-    bool PlayerReturnFire; // 1
-    bool PlayerScatter; // 2
-    bool ChronoKillCargo; // 4
+    bool Paranoid;
+    bool CurleyShuffle;
+    bool FlashLowPower;
+    bool CompEasyBonus;
+    bool FineDiffControl;
+    bool OreExplosive;
+    bool EnemyHealth;
+    bool MCVUndeploy;
+    bool AllyReveal;
+    bool SeparateAircraft;
+    bool TreeTargeting;
+    bool MineAware;
+    bool OreGrows;
+    bool OreSpreads;
+    bool NamedCivilians;
+    bool PlayerAutoCrush;
+    bool PlayerReturnFire;
+    bool PlayerScatter;
+    bool ChronoKillCargo;
     bool SecretUnitsEnabled;
     bool NewUnitsEnabled;
 #endif

--- a/src/game/engine/scenario.h
+++ b/src/game/engine/scenario.h
@@ -138,37 +138,30 @@ private:
     int BridgeCount;
     int CarryOverTime;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool _DestroyBridges : 1; // & 1 BridgeDestroyed?
-            bool _GlobalsChanged : 1; // & 2 VariablesChanged?
-            bool ToCarryOver : 1; // & 4
-            bool ToInherit : 1; // & 8
-            bool CivEvac : 1; // & 16
-            bool FadeOutBW : 1; // & 32 looks like FadeToBW
-            bool FadeInBW : 1; // & 64 and this looks like BWFadeReset
-            bool EndOfGame : 1; // & 128
-            bool TimerInherit : 1; // & 1
-            bool NoSpyPlane : 1; // & 2
-            bool SkipScore : 1; // & 4
-            bool OneTimeOnly : 1; // & 8
-            bool SkipMapSelect : 1; // & 16
-            bool TruckCrate : 1; // & 32
-            bool FillSilos : 1; // & 64
-        };
-        int Bitfield;
-    };
+    BOOL _DestroyBridges : 1; // & 1 BridgeDestroyed?
+    BOOL _GlobalsChanged : 1; // & 2 VariablesChanged?
+    BOOL ToCarryOver : 1; // & 4
+    BOOL ToInherit : 1; // & 8
+    BOOL CivEvac : 1; // & 16
+    BOOL FadeOutBW : 1; // & 32
+    BOOL FadeInBW : 1; // & 64
+    BOOL EndOfGame : 1; // & 128
+
+    BOOL TimerInherit : 1; // & 1
+    BOOL NoSpyPlane : 1; // & 2
+    BOOL SkipScore : 1; // & 4
+    BOOL OneTimeOnly : 1; // & 8
+    BOOL SkipMapSelect : 1; // & 16
+    BOOL TruckCrate : 1; // & 32
+    BOOL FillSilos : 1; // & 64
 #else
     bool _DestroyBridges; // BridgeDestroyed?
     bool _GlobalsChanged; // VariablesChanged?
     bool ToCarryOver;
     bool ToInherit;
     bool CivEvac;
-    bool FadeOutBW; // looks like FadeToBW
-    bool FadeInBW; // and this looks like BWFadeReset
+    bool FadeOutBW;
+    bool FadeInBW;
     bool EndOfGame;
     bool TimerInherit;
     bool NoSpyPlane;

--- a/src/game/engine/scroll.h
+++ b/src/game/engine/scroll.h
@@ -45,15 +45,7 @@ public:
 
 protected:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool Autoscroll : 1; // 1
-        };
-        int Bitfield;
-    };
+    BOOL Autoscroll : 1; // 1
 #else
     bool Autoscroll;
 #endif

--- a/src/game/engine/sidebar.h
+++ b/src/game/engine/sidebar.h
@@ -151,27 +151,18 @@ class SidebarClass : public PowerClass
         int YPos; // 0x15 -654
         int WhichColumn; // 0x19 -650
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-        // Union/Struct required to get correct packing when compiler packing set to 1.
-        union
-        {
-            struct
-            {
-                // bitfield 0x1D
-                bool StripToRedraw : 1; // 1
-                bool Strip_Boolean2 : 1; // 2
-                bool Strip_Boolean4 : 1; // 4    //related to some direction?
-                bool Strip_Boolean8 : 1; // 8    //Flags if the icons are scrolling?
-                bool Strip_Boolean16 : 1; // 16
-                bool Strip_Boolean32 : 1; // 32
-            };
-            int Bitfield;
-        };
+        BOOL StripToRedraw : 1; // 1
+        BOOL Strip_Boolean2 : 1; // 2
+        BOOL Strip_Boolean4 : 1; // 4    // related to some direction?
+        BOOL Strip_Boolean8 : 1; // 8    // Flags if the icons are scrolling?
+        BOOL Strip_Boolean16 : 1; // 16
+        BOOL Strip_Boolean32 : 1; // 32
 #else
         // bitfield 0x1D
         bool StripToRedraw; // 1
         bool Strip_Boolean2; // 2
-        bool Strip_Boolean4; // 4    //related to some direction?
-        bool Strip_Boolean8; // 8    //Flags if the icons are scrolling?
+        bool Strip_Boolean4; // 4    // related to some direction?
+        bool Strip_Boolean8; // 8    // Flags if the icons are scrolling?
         bool Strip_Boolean16; // 16
         bool Strip_Boolean32; // 32
 #endif
@@ -221,19 +212,11 @@ public:
 protected:
     StripClass Columns[COLUMN_COUNT];
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool SidebarIsDrawn : 1; // 1 when set to false, the sidebar is not drawn (for sidebar TAB hidding in C&C).
-            bool SidebarToRedraw : 1; // 2 buttons to redraw?
-            bool SidebarBit4 : 1; // 4 repair active
-            bool SidebarBit8 : 1; // 8 upgrade active
-            bool SidebarBit16 : 1; // 16 demolish active
-        };
-        int Bitfield;
-    };
+    BOOL SidebarIsDrawn : 1; // 1
+    BOOL SidebarToRedraw : 1; // 2 
+    BOOL SidebarBit4 : 1; // 4
+    BOOL SidebarBit8 : 1; // 8
+    BOOL SidebarBit16 : 1; // 16
 #else
     // bitfield 0x15F6
     bool SidebarIsDrawn; // when set to false, the sidebar is not drawn.(related to the sidebar TAB hidding in C&C)

--- a/src/game/engine/smudgetype.h
+++ b/src/game/engine/smudgetype.h
@@ -94,16 +94,8 @@ private:
     int Width;// Width in cells
     int Height; // Height in cells
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool Crater : 1; // 1 Crater smudges
-            bool Bib : 1; //2 Burn and Bib smudges
-        };
-        int Bitfield;
-    };
+    BOOL Crater : 1; // 1 Crater smudges
+    BOOL Bib : 1; //2 Burn and Bib smudges
 #else
     bool Crater; // Crater smudges
     bool Bib; // Burn and Bib smudges

--- a/src/game/engine/special.h
+++ b/src/game/engine/special.h
@@ -51,39 +51,40 @@ public:
 
 private:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
+    // Union/Struct required so we fetch the data easily with SpecialFlags.
     union
     {
         struct
         {
-            bool ShroudRegrows : 1; // & 1 Used in skirmish menu
-            bool BuildTimeAccelerated : 1; // & 2 Used in special dialog
-            bool FirstRun : 1; // & 4 Play intro followed by allied 1.
-            //bool DemoMode : 1; // & 4 activated by 0xD95C68A2 command shows the standby screen, the intro, then to allied 1.
-            bool CaptureTheFlag : 1; // & 8 Used in lan dialog, also checked in bridge destruction related code.
-            bool NoDamage : 1; // & 16 Used by Explosion_Damage code.
-            bool ThreePointTurnLogic : 1; // & 32 Used in hidden special dialog.
-            bool OreGrows : 1; // & 64 Set in skirmish menu
-            bool OreSpreads : 1; // & 128 Set in skirmish menu
+            BOOL ShroudRegrows : 1; // & 1
+            BOOL BuildTimeAccelerated : 1; // & 2
+            BOOL FirstRun : 1; // & 4
+            //BOOL DemoMode : 1; // & 4
+            BOOL CaptureTheFlag : 1; // & 8
+            BOOL NoDamage : 1; // & 16
+            BOOL ThreePointTurnLogic : 1; // & 32
+            BOOL OreGrows : 1; // & 64
+            BOOL OreSpreads : 1; // & 128
 
-            bool Spawned : 1; // & 1 "About to initialise Winsock" string RA demo, ow only skips intro and fades in the menu.
-            bool Remixes : 1; // & 2 Enable remix versions of audio tracks that have them. From C&C/Sole, absent from RA.
+            BOOL Spawned : 1; // & 1
+            BOOL Remixes : 1; // & 2
 
             //Bit3_1 is debug path finding is C&C Dos.
         };
         int SpecialFlags;
     };
 #else
-    bool ShroudRegrows;
-    bool BuildTimeAccelerated;
-    bool FirstRun;
-    bool CaptureTheFlag;
-    bool NoDamage;
-    bool ThreePointTurnLogic;
-    bool OreGrows;
-    bool OreSpreads;
-    bool Spawned;
-    bool Remixes;
+    bool ShroudRegrows; // Used in skirmish menu
+    bool BuildTimeAccelerated; //  Used in special dialog
+    bool FirstRun; // Play intro followed by allied 1 or soviet 1.
+    // bool DemoMode; // activated by 0xD95C68A2 command shows the standby screen, the intro, then to allied 1 or soviet 1.
+    bool CaptureTheFlag; // Used in lan dialog, also checked in bridge destruction related code.
+    bool NoDamage; // Used by Explosion_Damage code.
+    bool ThreePointTurnLogic; // Used in hidden special dialog.
+    bool OreGrows; // Set in skirmish menu
+    bool OreSpreads; // Set in skirmish menu
+    bool Spawned; // "About to initialise Winsock" string RA demo, now only skips intro and fades in the menu. For Wchat?
+    bool Remixes; // Enable remix versions of audio tracks that have them. From C&C/Sole, absent from RA.
 #endif
 };
 

--- a/src/game/engine/super.h
+++ b/src/game/engine/super.h
@@ -57,18 +57,10 @@ private:
 
 private:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_IsPowered : 1; // 1
-            bool m_IsEnabled : 1; // 2
-            bool m_OneTime : 1; // 4
-            bool m_FullyCharged : 1; // 8
-        };
-        int m_Bitfield;
-    };
+    BOOL m_IsPowered : 1; // 1
+    BOOL m_IsEnabled : 1; // 2
+    BOOL m_OneTime : 1; // 4
+    BOOL m_FullyCharged : 1; // 8
 #else
     bool m_IsPowered; // Does this super weapon become inoperative in a low power situation?
     bool m_IsEnabled; // 

--- a/src/game/engine/tab.h
+++ b/src/game/engine/tab.h
@@ -65,17 +65,9 @@ class TabClass : public SidebarClass
         int Available;
         int Credits;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-        // Union/Struct required to get correct packing when compiler packing set to 1.
-        union
-        {
-            struct
-            {
-                bool CreditToRedraw : 1; // & 1
-                bool CreditHasIncreased : 1; // & 2
-                bool CreditHasChanged : 1; // & 4
-            };
-            int Bitfield;
-        };
+        BOOL CreditToRedraw : 1; // & 1
+        BOOL CreditHasIncreased : 1; // & 2
+        BOOL CreditHasChanged : 1; // & 4
 #else
         bool CreditToRedraw;
         bool CreditHasIncreased;
@@ -108,15 +100,7 @@ protected:
     CreditClass CreditDisplay;
     TCountDownTimerClass<FrameTimerClass> TimerFlashTimer;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool TabToRedraw : 1; // 1
-        };
-        int Bitfield;
-    };
+    BOOL TabToRedraw : 1; // 1
 #else
     bool TabToRedraw;
 #endif

--- a/src/game/engine/team.h
+++ b/src/game/engine/team.h
@@ -58,49 +58,41 @@ private:
     GamePtr<HouseClass> m_Owner;
 
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_Bit1_1 : 1; // 1
-            bool m_Bit1_2 : 1; // 2
-            bool m_Bit1_4 : 1; // 4
-            bool m_ForcedActive : 1; // 8
-            bool m_Bit1_16 : 1; // 16
-            bool m_Bit1_32 : 1; // 32
-            bool m_Bit1_64 : 1; // 64
-            bool m_Bit1_128 : 1; // 128
+    BOOL m_Bit1_1 : 1; // 1
+    BOOL m_Bit1_2 : 1; // 2
+    BOOL m_Bit1_4 : 1; // 4
+    BOOL m_ForcedActive : 1; // 8
+    BOOL m_Bit1_16 : 1; // 16
+    BOOL m_Bit1_32 : 1; // 32
+    BOOL m_Bit1_64 : 1; // 64
+    BOOL m_Bit1_128 : 1; // 128
 
-            bool m_Bit2_1 : 1; // 1
-            bool m_Bit2_2 : 1; // 2
-            bool m_Bit2_4 : 1; // 4
-            bool m_Bit2_8 : 1; // 8
-            bool m_Bit2_16 : 1; // 16
-            bool m_Bit2_32 : 1; // 32
-            bool m_Bit2_64 : 1; // 64
-            bool m_Bit2_128 : 1; // 128
-        };
-        int m_Bitfield;
-    };
+    BOOL m_Bit2_1 : 1; // 1
+    BOOL m_Bit2_2 : 1; // 2
+    BOOL m_Bit2_4 : 1; // 4
+    BOOL m_Bit2_8 : 1; // 8
+    BOOL m_Bit2_16 : 1; // 16
+    BOOL m_Bit2_32 : 1; // 32
+    BOOL m_Bit2_64 : 1; // 64
+    BOOL m_Bit2_128 : 1; // 128
 #else
-    bool m_Bit1_1 : 1;
-    bool m_Bit1_2 : 1;
-    bool m_Bit1_4 : 1;
-    bool m_ForcedActive : 1;
-    bool m_Bit1_16 : 1;
-    bool m_Bit1_32 : 1;
-    bool m_Bit1_64 : 1;
-    bool m_Bit1_128 : 1;
+    bool m_Bit1_1;
+    bool m_Bit1_2;
+    bool m_Bit1_4;
+    bool m_ForcedActive;
+    bool m_Bit1_16;
+    bool m_Bit1_32;
+    bool m_Bit1_64;
+    bool m_Bit1_128;
 
-    bool m_Bit2_1 : 1;
-    bool m_Bit2_2 : 1;
-    bool m_Bit2_4 : 1;
-    bool m_Bit2_8 : 1;
-    bool m_Bit2_16 : 1;
-    bool m_Bit2_32 : 1;
-    bool m_Bit2_64 : 1;
-    bool m_Bit2_128 : 1;
+    bool m_Bit2_1;
+    bool m_Bit2_2;
+    bool m_Bit2_4;
+    bool m_Bit2_8;
+    bool m_Bit2_16;
+    bool m_Bit2_32;
+    bool m_Bit2_64;
+    bool m_Bit2_128;
 #endif
 
     target_t m_field_21;

--- a/src/game/engine/teamtype.h
+++ b/src/game/engine/teamtype.h
@@ -124,28 +124,21 @@ public:
 
 protected:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            /* //map bit, >> 1, as it goes past IsActive.
-            Always take the safest route, even if it's a detour  1
-            Charge at target ignoring enemy units/enemy fire  	2
-            Team is only used by autocreate AI (produced taskforces) 	4
-            Prebuild teammembers before creating team   	8
-            Automatically reinforce     	16
-            */
+    /*
+    //map bit, >> 1, as it goes past IsActive.
+    Always take the safest route, even if it’s a detour  1
+    Charge at target ignoring enemy units/enemy fire  	2
+    Team is only used by autocreate AI (produced taskforces) 	4
+    Prebuild teammembers before creating team   	8
+    Automatically reinforce     	16
+    */
 
-            bool m_IsActive : 1; // 1
-            bool m_AvoidThreats : 1; // 2
-            bool m_Suicide : 1; // 4
-            bool m_Autocreate : 1; // 8
-            bool m_Prebuild : 1; // 16
-            bool m_Reinforce : 1; // 32
-        };
-        int m_Bitfield;
-    };
+    BOOL m_IsActive : 1; // 1
+    BOOL m_AvoidThreats : 1; // 2
+    BOOL m_Suicide : 1; // 4
+    BOOL m_Autocreate : 1; // 8
+    BOOL m_Prebuild : 1; // 16
+    BOOL m_Reinforce : 1; // 32
 #else
     bool m_IsActive;
     bool m_AvoidThreats;

--- a/src/game/engine/techno.h
+++ b/src/game/engine/techno.h
@@ -189,27 +189,20 @@ protected:
     DoorClass m_Door;
     uint16_t m_KillCount;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_IsUseless : 1; // & 1
-            bool m_IsTickedOff : 1; // & 2 Has this object been attacked and pissed off?
-            bool m_Cloakable : 1; // & 4
-            bool m_IsPrimary : 1; // & 8
-            bool m_IsALoner : 1; // & 16
-            bool m_LockedOnMap : 1; // & 32
-            bool m_IsRecoiling : 1; // & 64
-            bool m_Tethered : 1; // & 128 Is this in radio chit chat with something (on repair bay, helipad etc)
-            bool m_PlayerOwned : 1; // & 1
-            bool m_PlayerAware : 1; // & 2 C&CDOS has this as "Discovered"
-            bool m_AIAware : 1; // & 4 maybe this is Discovered in C&C95?
-            bool m_Lemon : 1; // & 8"degrades" in OpenDUNE, seems to imply some decaying logic
-            bool m_Bit2_16 : 1; // & 16
-        };
-        int m_Bitfield;
-    };
+    BOOL m_IsUseless : 1; // & 1
+    BOOL m_IsTickedOff : 1; // & 2
+    BOOL m_Cloakable : 1; // & 4
+    BOOL m_IsPrimary : 1; // & 8
+    BOOL m_IsALoner : 1; // & 16
+    BOOL m_LockedOnMap : 1; // & 32
+    BOOL m_IsRecoiling : 1; // & 64
+    BOOL m_Tethered : 1; // & 128
+
+    BOOL m_PlayerOwned : 1; // & 1
+    BOOL m_PlayerAware : 1; // & 2
+    BOOL m_AIAware : 1; // & 4
+    BOOL m_Lemon : 1; // & 8
+    BOOL m_Bit2_16 : 1; // & 16
 #else
     bool m_IsUseless;
     bool m_IsTickedOff; // Has this object been attacked and pissed off?

--- a/src/game/engine/technotype.h
+++ b/src/game/engine/technotype.h
@@ -95,27 +95,19 @@ public:
 protected:
     RemapType Remap;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool DoubleOwned : 1; // 1 Can be built/owned by all countries in a multiplayer game (def = false)?
-            bool IsInvisible : 1; // 2 confirmed or RadarVisible, depending on how its used.
-            bool IsLeader : 1; // 4 99.9% sure, its set when a object has a valid Primary with Damage greater than 0.
-            bool IsScanner : 1; // 8 In TS this is Sensors?
-            bool IsNominal : 1; // 16 Always use the given name rather than generic "enemy object" (def = false)?
-            bool IsTheater : 1; // 32 Does it have theater specific imagery (def = false)?
-            bool IsTurretEquipped : 1; // 64
-            bool IsRepairable : 1; // 128
-            bool IsCrewed : 1; // 1 Does it contain a crew that can escape [never infantry] (def = false)?
-            bool IsRemapable : 1; // 2
-            bool Cloakable : 1; // 4 or NoMovingFire?
-            bool IsSelfHealing : 1; // 8 Does the object heal automatically up to half strength (def = false)?
-            bool Explodes : 1; // 16 Does it explode violently when destroyed(def = false)?
-        };
-        int Bitfield;
-    };
+    BOOL DoubleOwned : 1; // 1
+    BOOL IsInvisible : 1; // 2
+    BOOL IsLeader : 1; // 4
+    BOOL IsScanner : 1; // 8
+    BOOL IsNominal : 1; // 16
+    BOOL IsTheater : 1; // 32
+    BOOL IsTurretEquipped : 1; // 64
+    BOOL IsRepairable : 1; // 128
+    BOOL IsCrewed : 1; // 1
+    BOOL IsRemapable : 1; // 2
+    BOOL Cloakable : 1; // 4
+    BOOL IsSelfHealing : 1; // 8
+    BOOL Explodes : 1; // 16
 #else
     bool DoubleOwned; // Can be built/owned by all countries in a multiplayer game (def = false)?
     bool IsInvisible; // confirmed or RadarVisible, depending on how its used.

--- a/src/game/engine/terraintype.h
+++ b/src/game/engine/terraintype.h
@@ -106,15 +106,7 @@ public:
     uint32_t UnkInt; // Object bounds perhaps, packed coord?
     uint32_t Theater; // Bitfield of which theaters this terrain is allowed to appear in.
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool WaterBound : 1; // Is the terrain only allowed on the water (def = false)?
-        };
-        int Bitfield;
-    };
+    BOOL WaterBound : 1; // & 1
 #else
     bool WaterBound; // Is the terrain only allowed on the water (def = false)?
 #endif

--- a/src/game/engine/trigger.h
+++ b/src/game/engine/trigger.h
@@ -42,15 +42,7 @@ public:
 
 private:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_Bit1 : 1; // 1
-        };
-        int m_Bitfield;
-    };
+    BOOL m_Bit1 : 1; // 1
 #else
     bool m_Bit1;
 #endif
@@ -99,15 +91,7 @@ private:
     int m_HeapID;
     GamePtr<TriggerTypeClass> m_Type;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_IsActive : 1; // 1
-        };
-        int m_Bitfield;
-    };
+    BOOL m_IsActive : 1; // 1
 #else
     bool m_IsActive;
 #endif

--- a/src/game/engine/triggertype.h
+++ b/src/game/engine/triggertype.h
@@ -72,15 +72,7 @@ public:
 
 protected:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_IsActive : 1; // 1
-        };
-        int m_Bitfield;
-    };
+    BOOL m_IsActive : 1; // 1
 #else
     bool m_IsActive;
 #endif

--- a/src/game/engine/unit.h
+++ b/src/game/engine/unit.h
@@ -39,19 +39,11 @@ private:
     GamePtr<UnitTypeClass> m_Type;
     HousesType m_FlagOwner;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_Bit1 : 1; // 1
-            bool m_Bit2 : 1; // 2
-            bool m_Bit4 : 1; // 4
-            bool m_Bit8 : 1; // 8
-            bool m_Bit16 : 1; // 16
-    };
-        int m_Bitfield;
-};
+    BOOL m_Bit1 : 1; // 1
+    BOOL m_Bit2 : 1; // 2
+    BOOL m_Bit4 : 1; // 4
+    BOOL m_Bit8 : 1; // 8
+    BOOL m_Bit16 : 1; // 16
 #else
     bool m_Bit1;
     bool m_Bit2;

--- a/src/game/engine/unittype.h
+++ b/src/game/engine/unittype.h
@@ -93,34 +93,17 @@ public:
 
 private:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_CrateGoodie : 1;
-            bool m_Crusher : 1; // Is this vehicle able to crush infantry (def = false)?
-            bool m_Harvester : 1; // Does the special Ore harvesting rules apply (def = false)?
-            bool m_TurretSpins : 1; // Does the turret just sit and spin [only if turret equipped] (def = false)?
-            bool m_Bit16 : 1; // Causes the unit to start firing on itself if it has to drive to the location?
-            bool m_Bit32 : 1;
-            /*
-            00:27 < tomscncnet> started the game
-            00:29 < tomscncnet> aha
-            00:29 < tomscncnet> yea, so when it aquires a target on its own it turns the entire body to face it
-            00:29 < tomscncnet> with U on
-            00:30 < tomscncnet> but only when it does it itself
-            00:30 < tomscncnet> if i force fire it still turns the turret
-            00:30 < tomscncnet> heh its like a opposite of OmniFire
-            */
-            bool m_IsLarge : 1; // Is large unit for refresh purposes (refresh 48x48)
-            bool m_IsViceroid : 1; // Cycle through graphics viceroid style?
-            bool m_IsRadarJammer : 1;
-            bool m_IsMobileGapGen : 1;
-            bool m_NoMovingFire : 1; // The vehicle must stop before it can fire (def = false)?
-        };
-        int Bitfield;
-    };
+    BOOL m_CrateGoodie : 1;
+    BOOL m_Crusher : 1;
+    BOOL m_Harvester : 1;
+    BOOL m_TurretSpins : 1;
+    BOOL m_Bit16 : 1;
+    BOOL m_Bit32 : 1;
+    BOOL m_IsLarge : 1;
+    BOOL m_IsViceroid : 1;
+    BOOL m_IsRadarJammer : 1;
+    BOOL m_IsMobileGapGen : 1;
+    BOOL m_NoMovingFire : 1;
 #else
     bool m_CrateGoodie;
     bool m_Crusher; // Is this vehicle able to crush infantry (def = false)?

--- a/src/game/engine/version.h
+++ b/src/game/engine/version.h
@@ -71,18 +71,10 @@ private:
     unsigned m_minVersion;
     unsigned m_maxVersion;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_versionSet : 1; // & 1
-            bool m_majorSet : 1; // & 2
-            bool m_minorSet : 1; // & 4
-            bool m_fileRead : 1; // & 8
-        };
-        int m_versionFlags;
-    };
+    BOOL m_versionSet : 1; // & 1
+    BOOL m_majorSet : 1; // & 2
+    BOOL m_minorSet : 1; // & 4
+    BOOL m_fileRead : 1; // & 8
 #else
     bool m_versionSet;
     bool m_majorSet;

--- a/src/game/engine/vessel.h
+++ b/src/game/engine/vessel.h
@@ -94,16 +94,8 @@ class VesselClass : public DriveClass
 private:
     GamePtr<VesselTypeClass> m_Type;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_ToSelfRepair : 1; // 1
-            bool m_Repairing : 1; // 2
-        };
-        int m_Bitfield;
-    };
+    BOOL m_ToSelfRepair : 1; // 1
+    BOOL m_Repairing : 1; // 2
 #else
     bool m_ToSelfRepair; // 
     bool m_Repairing; // Is this vessel currently receiving repairs?

--- a/src/game/engine/vesseltype.h
+++ b/src/game/engine/vesseltype.h
@@ -75,15 +75,7 @@ public:
 
 private:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_UnkBool : 1; // & 1 Unknown, may relate to TS ini entry "Rotates".
-        };
-        int Bitfield;
-    };
+    BOOL m_UnkBool : 1; // & 1 Unknown, may relate to TS ini entry "Rotates".
 #else
     bool m_UnkBool; // Unknown, may relate to TS ini entry "Rotates".
 #endif

--- a/src/game/engine/warheadtype.h
+++ b/src/game/engine/warheadtype.h
@@ -78,18 +78,10 @@ private:
     const char *Name;
     int Spread; // damage spread factor[larger means greater spread]. Damage halves every n pixels from center.
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-                // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool Wall : 1; // Does this warhead damage concrete walls?
-            bool Wood : 1; // Does this warhead damage wood walls?
-            bool Ore : 1; // Does this warhead destroy ore?
-            bool UnkBool : 1; // Checked in InfantryClass::Greatest_Threat. Removes targets except infantry and harvester
-        };
-        int Bitfield;
-    };
+    BOOL Wall : 1;
+    BOOL Wood : 1;
+    BOOL Ore : 1;
+    BOOL UnkBool : 1;
 #else
     bool Wall; // Does this warhead damage concrete walls?
     bool Wood; // Does this warhead damage wood walls?

--- a/src/game/engine/weapontype.h
+++ b/src/game/engine/weapontype.h
@@ -120,18 +120,10 @@ private:
     int Type;
     const char *Name;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool TurboBoost : 1; // Should the weapon get a boosted speed bonus when firing upon aircraft?
-            bool Supress : 1; // Should nearby friendly buildings be scanned for and if found, discourage firing on target?
-            bool Camera : 1; // Reveals area around firer ?
-            bool Charges : 1; // Does it have charge-up-before-firing logic?
-        };
-        int Bitfield;
-    };
+    BOOL TurboBoost : 1;
+    BOOL Supress : 1;
+    BOOL Camera : 1;
+    BOOL Charges : 1;
 #else
     bool TurboBoost; // Should the weapon get a boosted speed bonus when firing upon aircraft?
     bool Supress; // Should nearby friendly buildings be scanned for and if found, discourage firing on target?

--- a/src/game/io/bfiofile.h
+++ b/src/game/io/bfiofile.h
@@ -60,20 +60,12 @@ public:
 #endif
 protected:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_bufferAllocated : 1; // & 1
-            bool m_bufferedFileAvailable : 1; // & 2
-            bool m_bufferedFileOpen : 1; // & 4
-            bool m_bufferFull : 1; // & 8
-            bool m_uncommited : 1; // & 0x10
-            bool m_buffered : 1; // & 0x20
-        };
-        int m_bufferFlags;
-    };
+    BOOL m_bufferAllocated : 1; // & 1
+    BOOL m_bufferedFileAvailable : 1; // & 2
+    BOOL m_bufferedFileOpen : 1; // & 4
+    BOOL m_bufferFull : 1; // & 8
+    BOOL m_uncommited : 1; // & 0x10
+    BOOL m_buffered : 1; // & 0x20
 #else
     bool m_bufferAllocated;
     bool m_bufferedFileAvailable;

--- a/src/game/io/cdfile.h
+++ b/src/game/io/cdfile.h
@@ -67,15 +67,7 @@ public:
 
 protected:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_disableSearchDrives : 1;
-        };
-        int m_cdFlags;
-    };
+    BOOL m_disableSearchDrives : 1;
 #else
     bool m_disableSearchDrives;
 #endif

--- a/src/game/io/mixfile.h
+++ b/src/game/io/mixfile.h
@@ -120,22 +120,13 @@ private:
 private:
     char *m_fileName;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool m_hasChecksum : 1;
-            bool m_isEncrypted : 1;
-            bool m_isAllocated : 1;
-        };
-        int m_flags;
-    };
+    BOOL m_hasChecksum : 1;
+    BOOL m_isEncrypted : 1;
+    BOOL m_isAllocated : 1;
 #else
     bool m_hasChecksum;
     bool m_isEncrypted;
     bool m_isAllocated;
-    bool m_useObscureHash;
 #endif
     int m_fileCount;
     int m_fileSize; // size of the body, not including this header and the index.

--- a/src/game/ui/droplist.h
+++ b/src/game/ui/droplist.h
@@ -55,15 +55,7 @@ public:
 
 protected:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool IsExpanded : 1; // & 1
-        };
-        int m_dropListFlags;
-    };
+    BOOL IsExpanded : 1; // & 1
 #else
     bool IsExpanded;
 #endif

--- a/src/game/ui/gadget.h
+++ b/src/game/ui/gadget.h
@@ -131,17 +131,9 @@ protected:
     int Height;
 
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool ToRedraw : 1; // & 1
-            bool IsSticky : 1; // & 2
-            bool IsDisabled : 1; // & 4
-        };
-        int m_gadgetFlags;
-    };
+    BOOL ToRedraw : 1; // & 1
+    BOOL IsSticky : 1; // & 2
+    BOOL IsDisabled : 1; // & 4
 #else
     bool ToRedraw;
     bool IsSticky;

--- a/src/game/ui/gauge.h
+++ b/src/game/ui/gauge.h
@@ -49,17 +49,9 @@ static void Hook_Me();
 
 protected:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool FillGauge : 1; // & 1
-            bool UseThumb : 1; // & 2
-            bool IsHorizontal : 1; // & 4
-        };
-        int m_gaugeFlags;
-    };
+    BOOL FillGauge : 1; // & 1
+    BOOL UseThumb : 1; // & 2
+    BOOL IsHorizontal : 1; // & 4
 #else
     bool FillGauge;
     bool UseThumb;

--- a/src/game/ui/list.h
+++ b/src/game/ui/list.h
@@ -72,15 +72,7 @@ protected:
     int YSpacing; // horziontal line spacing.
     int ThumbSize; // this visible is a line count/page size.
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-                   // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool HasScrollbar : 1; // & 1
-        };
-        int m_listFlags;
-    };
+    BOOL HasScrollbar : 1; // & 1
 #else
     bool HasScrollbar; // Does this List have a scroll bar for scrolling through the entries?
 #endif

--- a/src/game/ui/shapebtn.h
+++ b/src/game/ui/shapebtn.h
@@ -51,15 +51,7 @@ static void Hook_Me();
 
 protected:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool BooleanOne : 1; // & 1
-        };
-        int m_shapebtnFlags;
-    };
+    BOOL BooleanOne : 1; // & 1
 #else
     bool BooleanOne;
 #endif

--- a/src/game/ui/slider.h
+++ b/src/game/ui/slider.h
@@ -54,15 +54,7 @@ protected:
     ShapeButtonClass *ButtonPlus;
     ShapeButtonClass *ButtonMinus;
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool NoButtons : 1; // & 1
-        };
-        int m_sliderFlags;
-    };
+    BOOL NoButtons : 1; // & 1
 #else
     bool NoButtons; // 1
 #endif

--- a/src/game/ui/textbtn.h
+++ b/src/game/ui/textbtn.h
@@ -50,17 +50,9 @@ private:
 
 protected:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool HasOutline : 1; // & 1
-            bool FilledBackground : 1; // & 2
-            bool HasShadow : 1; // & 4
-        };
-        int m_toggleFlags;
-    };
+    BOOL HasOutline : 1; // & 1
+    BOOL FilledBackground : 1; // & 2
+    BOOL HasShadow : 1; // & 4
 #else
     bool HasOutline;
     bool FilledBackground;

--- a/src/game/ui/toggle.h
+++ b/src/game/ui/toggle.h
@@ -44,17 +44,9 @@ public:
 
 protected:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
-    // Union/Struct required to get correct packing when compiler packing set to 1.
-    union
-    {
-        struct
-        {
-            bool Toggle_Boolean1 : 1; // & 1
-            bool ToggleState : 1; // & 2
-            bool ToggleDisabled : 1; // & 4
-        };
-        int m_toggleFlags;
-    };
+    BOOL Toggle_Boolean1 : 1; // & 1
+    BOOL ToggleState : 1; // & 2
+    BOOL ToggleDisabled : 1; // & 4
 #else
     bool Toggle_Boolean1;
     bool ToggleState;


### PR DESCRIPTION
This is how Westwood originally had bitfields based matching assembly generated by Watcom when bitfields are declared like this.