### PR TITLE
Implements Shorten_Attached_Anims, fixes hook for Terrain Take_Damage.

### DIFF
--- a/src/game/engine/anim.h
+++ b/src/game/engine/anim.h
@@ -66,7 +66,9 @@ public:
     coord_t Adjust_Coord(coord_t coord);
     static void Do_Atom_Damage(HousesType house, cell_t cell);
 
+    target_t Attached_To() const { return m_AttachedTo; }
     unsigned char Get_Loops() const { return m_Loops; }
+    void Set_Loops(unsigned char loops) { m_Loops = loops; }
     void Make_Invisible() { m_Invisible = true; }
     BOOL Is_Invisible() const { return m_Invisible; }
     unsigned int Get_Loop_Delay() const { return m_LoopDelay; }

--- a/src/game/engine/object.cpp
+++ b/src/game/engine/object.cpp
@@ -22,7 +22,7 @@
 #include "house.h"
 #include "globals.h"
 #include "session.h"
-//#include "anim.h"
+#include "anim.h"
 #include "special.h"
 #include "tracker.h"
 #include "foot.h"
@@ -855,12 +855,14 @@ void Unselect_All()
 
 void ObjectClass::Shorten_Attached_Anims()
 {
-#ifdef GAME_DLL
-    void(*func)(ObjectClass *) = reinterpret_cast<void(*)(ObjectClass *)>(0x00423F20);
-    func(this);
-#else
-    // TODO: Requires AnimClass.
-#endif
+    for (int i = 0; i < g_Anims.Count(); ++i) {
+        AnimClass *aptr = &g_Anims[i];
+        if (aptr != nullptr) {
+            if (As_Object(aptr->Attached_To()) == this) {
+                aptr->Set_Loops(0);
+            }
+        }
+    }
 }
 
 void ObjectClass::Detach_This_From_All(target_t object, BOOL unk)

--- a/src/hooker/setuphooks.cpp
+++ b/src/hooker/setuphooks.cpp
@@ -867,7 +867,7 @@ void Setup_Hooks()
     Hook_Function(0x0056AAB4, *TerrainClass::Unlimbo);
     Hook_Function(0x0056A5AC, *TerrainClass::Hook_Draw_It);
     Hook_Function(0x0056A510, *TerrainClass::Mark);
-    Hook_Function(0x0057AAE8, *TerrainClass::Take_Damage);
+    Hook_Function(0x0056A2FC, *TerrainClass::Take_Damage);
     Hook_Function(0x0056A734, *TerrainClass::Catch_Fire);
     Hook_Function(0x0056A854, *TerrainClass::Fire_Out);
     Hook_Function(0x0056AB08, *TerrainClass::Start_To_Crumble);


### PR DESCRIPTION
Possibly fixes #139, and #137
Shorten function isn't static in ours so best implement it to avoid crashes, hook address was UnitClass::Take_Damage() so it broke Terrain objects on damage.