### PR TITLE
Fixes to TeamType and TriggerType members. Fixes to Coord_Spillage_List

### DIFF
--- a/src/game/engine/coord.cpp
+++ b/src/game/engine/coord.cpp
@@ -232,18 +232,21 @@ const int16_t *Coord_Spillage_List(coord_t coord, int size)
     // clang-format on
 
     // Its big, just use the big refresh list.
-    if (size > 48) {
+    if (size > CELL_PIXELS * 2) {
         return _gigundo;
     }
 
-    if (size > 24) {
+    if (size > CELL_PIXELS) {
         // Calculate the rect we need to consider.
-        int adjust = std::min(size, 48) / 2;
+        int adjust = std::min(size, CELL_PIXELS * 2) / 2;
         unsigned index = 0;
-        int x_lo = Lepton_To_Pixel(Coord_Sub_Cell_X(coord)) - adjust;
-        int x_hi = Lepton_To_Pixel(Coord_Sub_Cell_X(coord)) + adjust;
-        int y_lo = Lepton_To_Pixel(Coord_Sub_Cell_Y(coord)) - adjust;
-        int y_hi = Lepton_To_Pixel(Coord_Sub_Cell_Y(coord)) + adjust;
+
+        int x = CELL_PIXELS * Coord_Sub_Cell_X(coord) / CELL_LEPTONS;
+        int y = CELL_PIXELS * Coord_Sub_Cell_Y(coord) / CELL_LEPTONS;
+        int x_lo = x - adjust;
+        int x_hi = x + adjust;
+        int y_lo = y - adjust;
+        int y_hi = y + adjust;
 
         // Construct a refresh list based on where rect lies relative to cell boundaries.
         _manual[index++] = 0;
@@ -253,7 +256,7 @@ const int16_t *Coord_Spillage_List(coord_t coord, int size)
             _manual[index++] = -1;
         }
 
-        if (x_hi > 24) {
+        if (x_hi >= CELL_PIXELS) {
             _manual[index++] = 1;
         }
 
@@ -262,7 +265,7 @@ const int16_t *Coord_Spillage_List(coord_t coord, int size)
             _manual[index++] = -128;
         }
 
-        if (y_hi > 24) {
+        if (y_hi >= CELL_PIXELS) {
             _manual[index++] = 128;
         }
 
@@ -271,15 +274,15 @@ const int16_t *Coord_Spillage_List(coord_t coord, int size)
             _manual[index++] = -129;
         }
 
-        if (x_hi > 24 && y_hi > 24) {
+        if (x_hi >= CELL_PIXELS && y_hi >= CELL_PIXELS) {
             _manual[index++] = 129;
         }
 
-        if (x_lo < 0 && y_hi > 24) {
+        if (x_lo < 0 && y_hi >= CELL_PIXELS) {
             _manual[index++] = 127;
         }
 
-        if (x_hi > 24 && y_lo < 0) {
+        if (x_hi >= CELL_PIXELS && y_lo < 0) {
             _manual[index++] = -127;
         }
 
@@ -288,7 +291,7 @@ const int16_t *Coord_Spillage_List(coord_t coord, int size)
         return _manual;
     }
 
-    int ref = _pix_to_lepton[(24 - size) / 2];
+    int ref = _pix_to_lepton[(CELL_PIXELS - size) / 2];
     int x = Coord_Sub_Cell_X(coord) - 128;
     int y = Coord_Sub_Cell_Y(coord) - 128;
     uint8_t index = 0;

--- a/src/game/engine/foot.cpp
+++ b/src/game/engine/foot.cpp
@@ -662,8 +662,7 @@ PathType *FootClass::Find_Path(cell_t dest, FacingType *buffer, int length, Move
 
     BENCHMARK_START(BENCH_FIND_PATH);
 
-    // Are we part of a team and should that team avoid threats?
-    if (!m_Team.Is_Valid() || !m_Team->Should_Avoid_Threats()) {
+    if (!m_Team.Is_Valid() || !m_Team->Is_Roundabout()) {
         // captainslog_debug(" Threat procesing will not be performed for final cell.");
         threat = -1;
         risk = -1;

--- a/src/game/engine/house.cpp
+++ b/src/game/engine/house.cpp
@@ -1418,6 +1418,7 @@ coord_t HouseClass::Find_Build_Location(BuildingClass *building) const
             cell_t zonecell = Find_Cell_In_Zone(building, _zones[zone % ZONE_COUNT]);
 
             if (Valid_Cell(zonecell)) {
+                // BUGFIX: Previously, this incorrectly returned just the cell, now we properly convert to a coord.
                 return Cell_To_Coord(zonecell);
             }
         }

--- a/src/game/engine/team.cpp
+++ b/src/game/engine/team.cpp
@@ -63,8 +63,8 @@ TeamClass::TeamClass(TeamTypeClass *teamtype, HouseClass *house) :
 
     memset(m_Quantity, 0, sizeof(m_Quantity));
 
-    if (m_Class->Get_Location() != -1) {
-        cell_t cellnum = g_Scen.Get_Waypoint(m_Class->Get_Location());
+    if (m_Class->Get_Waypoint() != -1) {
+        cell_t cellnum = g_Scen.Get_Waypoint(m_Class->Get_Waypoint());
         m_Center = ::As_Target(cellnum);
     }
 

--- a/src/game/engine/team.h
+++ b/src/game/engine/team.h
@@ -51,7 +51,7 @@ public:
     void Decode_Pointers();
 
     void Force_Active() { m_ForcedActive = true; }
-    BOOL Should_Avoid_Threats() const { return m_Class->Avoid_Threats(); }
+    BOOL Is_Roundabout() const { return m_Class->Roundabout(); }
     int Field35() const { return m_field_35; }
     BOOL Get_Bit2_4() const { return m_Bit2_4; }
     void Set_Bit2_4(BOOL state) { m_Bit2_4 = state; }

--- a/src/game/engine/teamtype.h
+++ b/src/game/engine/teamtype.h
@@ -108,11 +108,11 @@ public:
     void Code_Pointers();
     void Decode_Pointers();
 
-    BOOL Avoid_Threats() const { return m_AvoidThreats; }
+    BOOL Roundabout() const { return m_Roundabout; }
     void Add_Instance() { ++m_Instances; }
     void Remove_Instance() { --m_Instances; }
     HousesType Get_Owner() const { return m_Owner; }
-    int Get_Location() const { return m_Location; }
+    int Get_Waypoint() const { return m_Waypoint; }
     const GamePtr<TriggerTypeClass> &Get_TriggerType() const { return m_TriggerType; }
 
     static void Init();
@@ -138,26 +138,28 @@ private:
 protected:
 #ifndef CHRONOSHIFT_NO_BITFIELDS
     BOOL m_IsActive : 1; // 1
-    BOOL m_AvoidThreats : 1; // 2
+    BOOL m_Roundabout : 1; // 2
     BOOL m_Suicide : 1; // 4
     BOOL m_Autocreate : 1; // 8
     BOOL m_Prebuild : 1; // 16
     BOOL m_Reinforce : 1; // 32
+    BOOL m_Bit64 : 1; // 64
 #else
     bool m_IsActive;
-    bool m_AvoidThreats; // Always take the safest route, even if it’s a detour.
+    bool m_Roundabout; // Always take the safest route, even if it's a detour.
     bool m_Suicide; // Charge at target ignoring enemy units/enemy fire.
     bool m_Autocreate; // Team is only used by autocreate AI (produced taskforces).
     bool m_Prebuild; // Prebuild team members before creating.
     bool m_Reinforce; // Automatically reinforce.
+    bool m_Bit64;
 #endif
     int m_Priority;
-    uint8_t m_Number;
-    uint8_t m_Max;
-    uint8_t m_Unused;
+    uint8_t m_InitialNumber;
+    uint8_t m_MaxAllowed; // Maximum number of instances of this TeamType that can exist at the same time.
+    uint8_t m_Fear;
     HousesType m_Owner;
     GamePtr<TriggerTypeClass> m_TriggerType;
-    int m_Location;
+    int m_Waypoint;
     int m_Instances;
     int m_MissionCount;
     TeamMissionClass m_Missions[20];

--- a/src/game/engine/triggertype.cpp
+++ b/src/game/engine/triggertype.cpp
@@ -52,7 +52,7 @@ TFixedIHeapClass<TriggerTypeClass> g_TriggerTypes;
 
 TriggerTypeClass::TriggerTypeClass() :
     AbstractTypeClass(RTTI_TRIGGERTYPE, g_TriggerTypes.ID(this), 0, "x"),
-    m_State(STATE_VOLATILE),
+    m_Existence(PERSIST_VOLATILE),
     m_House(HOUSES_FIRST),
     m_EventLinkage(EVLINK_SINGLE),
     m_ActionLinkage(ACTLINK_SINGLE)
@@ -781,11 +781,11 @@ BOOL TriggerTypeClass::Edit()
         dn_btn);
 
     // Populate the lists.
-    for (PersistanceType i = STATE_FIRST; i < STATE_COUNT; ++i) {
+    for (PersistanceType i = PERSIST_FIRST; i < PERSIST_COUNT; ++i) {
         persist_list_edit.Add_Item(_perstext[i]);
     }
 
-    persist_list_edit.Set_Selected_Index(m_State);
+    persist_list_edit.Set_Selected_Index(m_Existence);
 
     // *** Setup buttons and intial gadget linkage state.
     TextButtonClass button_event(148,
@@ -1230,7 +1230,7 @@ BOOL TriggerTypeClass::Edit()
 
     // Save all the valuees from the gadgets to the class.
     m_House = (HousesType)owner_list_edit.Current_Index();
-    m_State = (PersistanceType)persist_list_edit.Current_Index();
+    m_Existence = (PersistanceType)persist_list_edit.Current_Index();
 
     if (strlen(name_buf) == 0) {
         strlcpy(m_Name, "____", sizeof(m_Name));
@@ -1423,10 +1423,10 @@ const char *TriggerTypeClass::Description()
     char act_link;
     const char *need;
 
-    switch (m_State) {
-        case STATE_SEMI_PERSISTANT:
+    switch (m_Existence) {
+        case PERSIST_SEMI_PERSISTANT:
             persist_type = 'S';
-        case STATE_PERSISTANT:
+        case PERSIST_PERSISTANT:
             persist_type = 'P';
             break;
         default:
@@ -1649,7 +1649,7 @@ TriggerTypeClass *TriggerTypeClass::As_Pointer(TriggerType type)
 void TriggerTypeClass::Fill_In(const char *name, char *options)
 {
     strlcpy(m_Name, name, sizeof(m_Name));
-    m_State = PersistanceType(atoi(strtok(options, ",")));
+    m_Existence = PersistanceType(atoi(strtok(options, ",")));
     m_House = HousesType(atoi(strtok(nullptr, ",")));
     m_EventLinkage = EventLinkType(atoi(strtok(nullptr, ",")));
     m_ActionLinkage = ActionLinkType(atoi(strtok(nullptr, ",")));
@@ -1664,7 +1664,7 @@ void TriggerTypeClass::Fill_In(const char *name, char *options)
  */
 void TriggerTypeClass::Build_INI_Entry(char *buffer)
 {
-    sprintf(buffer, "%d,%d,%d,%d,", m_State, m_House, m_EventLinkage, m_ActionLinkage);
+    sprintf(buffer, "%d,%d,%d,%d,", m_Existence, m_House, m_EventLinkage, m_ActionLinkage);
     m_EventOne.Build_INI_Entry(&buffer[strlen(buffer)]);
     strcat(buffer, ",");
     m_EventTwo.Build_INI_Entry(&buffer[strlen(buffer)]);

--- a/src/game/engine/triggertype.h
+++ b/src/game/engine/triggertype.h
@@ -39,12 +39,12 @@ DEFINE_ENUMERATION_OPERATORS(TriggerType);
 
 enum PersistanceType
 {
-    STATE_NONE = -1,
-    STATE_VOLATILE, // Will only ever be activated once.
-    STATE_SEMI_PERSISTANT, // Will only trigger once the trigger event has all conditions have been met.
-    STATE_PERSISTANT, // Will continue to repeat itself whenever its trigger event is true.
-    STATE_COUNT,
-    STATE_FIRST = 0,
+    PERSIST_NONE = -1,
+    PERSIST_VOLATILE, // Will only ever be activated once.
+    PERSIST_SEMI_PERSISTANT, // Will only trigger once the trigger event has all conditions have been met.
+    PERSIST_PERSISTANT, // Will continue to repeat itself whenever its trigger event is true.
+    PERSIST_COUNT,
+    PERSIST_FIRST = 0,
 };
 
 DEFINE_ENUMERATION_OPERATORS(PersistanceType);
@@ -124,7 +124,7 @@ protected:
     bool m_IsActive;
 #endif
 
-    PersistanceType m_State;
+    PersistanceType m_Existence;
     HousesType m_House;
     TEventClass m_EventOne;
     TEventClass m_EventTwo;


### PR DESCRIPTION
AvoidThreats is wrong, this is a generation 2 engine feature used by AStar code. Chose the name Roundabout as its slang for safest even if longest route.
TeamType had bit 64, but can't seem to find a use for it other than clearing in constructor.
Team Types in Dune 2 apparently had a Fear counter, the location of this checks out.
Location is a misleading name as it could mean cell, coord or pixel location, its a waypoint therefore it should be called Waypoint.
TriggerType persistence isn't a state per say, for it to be a state it should be able to change. It's more of a definition of how the trigger exists. Accordingly PersistanceType enum is corrected.