### PR TITLE
Expansions

### DIFF
--- a/src/game/engine/expansion.cpp
+++ b/src/game/engine/expansion.cpp
@@ -14,6 +14,7 @@
  *            LICENSE
  */
 #include "expansion.h"
+#include "gamefile.h"
 #include "gameoptions.h"
 #include <captainslog.h>
 
@@ -23,78 +24,84 @@
 
 BOOL Is_Counterstrike_Installed()
 {
-    if (g_Options.Expansion_Options_Present()) {
-        return g_Options.Is_Counterstrike_Enabled();
-    }
-#ifdef PLATFORM_WINDOWS
-    captainslog_debug("Counterstrike install check from chronoshift.ini failed, checking registry.");
     static BOOL _checked;
     static BOOL _installed;
-    HKEY result;
 
-    if (!_checked) {
+    if (g_Options.Expansion_Options_Present()) {
+        return g_Options.Is_Counterstrike_Enabled();
+    } else if (!_checked) {
+#ifdef PLATFORM_WINDOWS
+        HKEY result;
+        captainslog_debug("Expansion options in chronoshift.ini not present, checking registry for Counterstrike.");
+
         if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Westwood\\Red Alert Windows 95 Edition", 0, KEY_READ, &result)
-            != 0) {
-            captainslog_debug(
-                "Failed to open 'SOFTWARE\\Westwood\\Red Alert Windows 95 Edition' subkey in %s.", __CURRENT_FUNCTION__);
-            return false;
+            == 0) {
+            DWORD cbdata = 4;
+            BYTE data[4];
+
+            if (RegQueryValueExA(result, "CStrikeInstalled", nullptr, nullptr, data, &cbdata) != 0) {
+                _installed = false;
+            } else {
+                captainslog_debug(
+                    "Query succeeded, registry value for Counterstrike is %d.", *reinterpret_cast<DWORD *>(data));
+                _installed = *reinterpret_cast<DWORD *>(data);
+            }
+
+            RegCloseKey(result);
+            _checked = true;
         }
+#endif
 
-        DWORD cbdata = 4;
-        BYTE data[4];
-
-        if (RegQueryValueExA(result, "CStrikeInstalled", nullptr, nullptr, data, &cbdata) != 0) {
-            _installed = false;
-        } else {
-            captainslog_debug("Query succeeded, registry value for Counterstrike is %d.", *reinterpret_cast<DWORD *>(data));
-            _installed = *reinterpret_cast<DWORD *>(data);
+        if (!_checked) {
+            captainslog_debug("Expansion options in chronoshift.ini not present, checking for expand.mix for Counterstrike.");
+            GameFileClass fc("expand.mix");
+            _installed = fc.Is_Available();
+            _checked = true;
         }
-
-        RegCloseKey(result);
-        _checked = true;
     }
 
     return _installed;
-#else
-    return false;
-#endif
 }
+
 
 BOOL Is_Aftermath_Installed()
 {
-    if (g_Options.Expansion_Options_Present()) {
-        return g_Options.Is_Aftermath_Enabled();
-    }
-#ifdef PLATFORM_WINDOWS
-    captainslog_debug("Aftermath install check from chronoshift.ini failed, checking registry.");
     static BOOL _checked;
     static BOOL _installed;
-    HKEY result;
 
-    if (!_checked) {
+    if (g_Options.Expansion_Options_Present()) {
+        return g_Options.Is_Aftermath_Enabled();
+    } else if (!_checked) {
+#ifdef PLATFORM_WINDOWS
+        HKEY result;
+        captainslog_debug("Expansion options in chronoshift.ini not present, checking registry for Aftermath.");
+
         if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Westwood\\Red Alert Windows 95 Edition", 0, KEY_READ, &result)
-            != 0) {
+            == 0) {
+            DWORD cbdata = 4;
+            BYTE data[4];
+
+            if (RegQueryValueExA(result, "AftermathInstalled", nullptr, nullptr, data, &cbdata) != 0) {
+                _installed = false;
+            } else {
+                captainslog_debug(
+                    "Query succeeded, registry value for Aftermath is %d.", *reinterpret_cast<DWORD *>(data));
+                _installed = *reinterpret_cast<DWORD *>(data);
+            }
+
+            RegCloseKey(result);
+            _checked = true;
+        }
+#endif
+
+        if (!_checked) {
             captainslog_debug(
-                "Failed to open 'SOFTWARE\\Westwood\\Red Alert Windows 95 Edition' subkey in %s.", __CURRENT_FUNCTION__);
-            return false;
+                "Expansion options in chronoshift.ini not present, checking for expand2.mix for Aftermath.");
+            GameFileClass fc("expand2.mix");
+            _installed = fc.Is_Available();
+            _checked = true;
         }
-
-        DWORD cbdata = 4;
-        BYTE data[4];
-
-        if (RegQueryValueExA(result, "AftermathInstalled", nullptr, nullptr, data, &cbdata) != 0) {
-            _installed = false;
-        } else {
-            captainslog_debug("Query succeeded, registry value for Aftermath is %d.", *reinterpret_cast<DWORD *>(data));
-            _installed = *reinterpret_cast<DWORD *>(data);
-        }
-
-        RegCloseKey(result);
-        _checked = true;
     }
 
     return _installed;
-#else
-    return false;
-#endif
 }

--- a/src/game/engine/expansion.cpp
+++ b/src/game/engine/expansion.cpp
@@ -15,6 +15,7 @@
  */
 #include "expansion.h"
 #include "gameoptions.h"
+#include <captainslog.h>
 
 #ifdef PLATFORM_WINDOWS
 #include <winreg.h>
@@ -26,21 +27,26 @@ BOOL Is_Counterstrike_Installed()
         return true;
     }
 #ifdef PLATFORM_WINDOWS
+    captainslog_debug("Counterstrike install check from chronoshift.ini failed, checking registry.");
     static BOOL _checked;
     static BOOL _installed;
     HKEY result;
-    BYTE data[4];
-    DWORD cbdata;
 
     if (!_checked) {
         if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Westwood\\Red Alert Windows 95 Edition", 0, KEY_READ, &result)
             != 0) {
+            captainslog_debug(
+                "Failed to open 'SOFTWARE\\Westwood\\Red Alert Windows 95 Edition' subkey in %s.", __CURRENT_FUNCTION__);
             return false;
         }
+
+        DWORD cbdata = 4;
+        BYTE data[4];
 
         if (RegQueryValueExA(result, "CStrikeInstalled", nullptr, nullptr, data, &cbdata) != 0) {
             _installed = false;
         } else {
+            captainslog_debug("Query succeeded, registry value for Counterstrike is %d.", *reinterpret_cast<DWORD *>(data));
             _installed = *reinterpret_cast<DWORD *>(data);
         }
 
@@ -60,21 +66,26 @@ BOOL Is_Aftermath_Installed()
         return true;
     }
 #ifdef PLATFORM_WINDOWS
+    captainslog_debug("Aftermath install check from chronoshift.ini failed, checking registry.");
     static BOOL _checked;
     static BOOL _installed;
     HKEY result;
-    BYTE data[4];
-    DWORD cbdata;
 
     if (!_checked) {
         if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Westwood\\Red Alert Windows 95 Edition", 0, KEY_READ, &result)
             != 0) {
+            captainslog_debug(
+                "Failed to open 'SOFTWARE\\Westwood\\Red Alert Windows 95 Edition' subkey in %s.", __CURRENT_FUNCTION__);
             return false;
         }
+
+        DWORD cbdata = 4;
+        BYTE data[4];
 
         if (RegQueryValueExA(result, "AftermathInstalled", nullptr, nullptr, data, &cbdata) != 0) {
             _installed = false;
         } else {
+            captainslog_debug("Query succeeded, registry value for Aftermath is %d.", *reinterpret_cast<DWORD *>(data));
             _installed = *reinterpret_cast<DWORD *>(data);
         }
 

--- a/src/game/engine/expansion.cpp
+++ b/src/game/engine/expansion.cpp
@@ -23,8 +23,8 @@
 
 BOOL Is_Counterstrike_Installed()
 {
-    if (g_Options.Is_Counterstrike_Enabled()) {
-        return true;
+    if (g_Options.Expansion_Options_Present()) {
+        return g_Options.Is_Counterstrike_Enabled();
     }
 #ifdef PLATFORM_WINDOWS
     captainslog_debug("Counterstrike install check from chronoshift.ini failed, checking registry.");
@@ -62,8 +62,8 @@ BOOL Is_Counterstrike_Installed()
 
 BOOL Is_Aftermath_Installed()
 {
-    if (g_Options.Is_Aftermath_Enabled()) {
-        return true;
+    if (g_Options.Expansion_Options_Present()) {
+        return g_Options.Is_Aftermath_Enabled();
     }
 #ifdef PLATFORM_WINDOWS
     captainslog_debug("Aftermath install check from chronoshift.ini failed, checking registry.");

--- a/src/game/engine/options.cpp
+++ b/src/game/engine/options.cpp
@@ -103,6 +103,7 @@ OptionsClass::OptionsClass() :
     m_AllowSidebarToggle(false),
     m_CounterstrikeEnabled(false),
     m_AftermathEnabled(false),
+    m_ExpansionOptionsPresent(false),
     m_KeyForceMove1(KN_LALT),
     m_KeyForceMove2(KN_RALT),
     m_KeyForceAttack1(KN_LCTRL),
@@ -260,8 +261,12 @@ void OptionsClass::Save_Settings()
     ini.Put_Bool("Options", "FreeScrolling", m_FreeScrolling);
     ini.Put_Bool("Options", "DeathAnnounce", m_DeathAnnounce);
     ini.Put_Bool("Options", "AllowSidebarToggle", m_AllowSidebarToggle);
-    ini.Put_Bool("Expansions", "CounterstrikeEnabled", m_CounterstrikeEnabled);
-    ini.Put_Bool("Expansions", "AftermathEnabled", m_AftermathEnabled);
+
+    // Only add the expansion enable bools if the section already exists in the file.
+    if (ini.Section_Present("Expansions")) {
+        ini.Put_Bool("Expansions", "CounterstrikeEnabled", m_CounterstrikeEnabled);
+        ini.Put_Bool("Expansions", "AftermathEnabled", m_AftermathEnabled);
+    }
 
     ini.Put_KeyNumType("WinHotkeys", "KeyForceMove1", m_KeyForceMove1);
     ini.Put_KeyNumType("WinHotkeys", "KeyForceMove2", m_KeyForceMove2);
@@ -348,6 +353,7 @@ void OptionsClass::Load_Settings()
     m_AllowSidebarToggle = ini.Get_Bool("Options", "AllowSidebarToggle", false); // TODO use variable as default when ctor used.
     m_CounterstrikeEnabled = ini.Get_Bool("Expansions", "CounterstrikeEnabled", false); // TODO use variable as default when ctor used.
     m_AftermathEnabled = ini.Get_Bool("Expansions", "AftermathEnabled", false); // TODO use variable as default when ctor used.
+    m_ExpansionOptionsPresent = ini.Section_Present("Expansions");
 
     m_KeyForceMove1 = ini.Get_KeyNumType("WinHotkeys", "KeyForceMove1", m_KeyForceMove1);
     m_KeyForceMove2 = ini.Get_KeyNumType("WinHotkeys", "KeyForceMove2", m_KeyForceMove2);

--- a/src/game/engine/options.cpp
+++ b/src/game/engine/options.cpp
@@ -262,8 +262,8 @@ void OptionsClass::Save_Settings()
     ini.Put_Bool("Options", "DeathAnnounce", m_DeathAnnounce);
     ini.Put_Bool("Options", "AllowSidebarToggle", m_AllowSidebarToggle);
 
-    // Only add the expansion enable bools if the section already exists in the file.
-    if (ini.Section_Present("Expansions")) {
+    // Only add the expansion enable bools if having the options at all is enabled.
+    if (m_ExpansionOptionsPresent) {
         ini.Put_Bool("Expansions", "CounterstrikeEnabled", m_CounterstrikeEnabled);
         ini.Put_Bool("Expansions", "AftermathEnabled", m_AftermathEnabled);
     }

--- a/src/game/engine/options.h
+++ b/src/game/engine/options.h
@@ -85,6 +85,7 @@ public:
     BOOL Is_Counterstrike_Enabled() const { return m_CounterstrikeEnabled; }
     BOOL Is_Aftermath_Enabled() const { return m_AftermathEnabled; }
     BOOL Expansion_Options_Present() const { return m_ExpansionOptionsPresent; }
+    void Enable_Expansion_Options() { m_ExpansionOptionsPresent = true; }
     fixed_t Get_Brightness() const { return (m_Brightness - fixed_t::_1_4) / fixed_t::_1_2; }
     fixed_t Get_Saturation() const { return m_Saturation; }
     fixed_t Get_Contrast() const { return (m_Contrast - fixed_t::_1_4) / fixed_t::_1_2; }

--- a/src/game/engine/options.h
+++ b/src/game/engine/options.h
@@ -84,6 +84,7 @@ public:
     BOOL Free_Scrolling() const { return m_FreeScrolling; }
     BOOL Is_Counterstrike_Enabled() const { return m_CounterstrikeEnabled; }
     BOOL Is_Aftermath_Enabled() const { return m_AftermathEnabled; }
+    BOOL Expansion_Options_Present() const { return m_ExpansionOptionsPresent; }
     fixed_t Get_Brightness() const { return (m_Brightness - fixed_t::_1_4) / fixed_t::_1_2; }
     fixed_t Get_Saturation() const { return m_Saturation; }
     fixed_t Get_Contrast() const { return (m_Contrast - fixed_t::_1_4) / fixed_t::_1_2; }
@@ -209,6 +210,7 @@ private:
     BOOL m_AllowSidebarToggle : 1; // & 64 Chronoshift option.
     BOOL m_CounterstrikeEnabled : 1; // & 128 Chronoshift option.
     BOOL m_AftermathEnabled : 1; // & 256 Chronoshift option.
+    BOOL m_ExpansionOptionsPresent : 1; // & 512 Chronoshift option.
 #else
     bool m_AutoScroll;
     bool m_ScoreRepeats;
@@ -219,6 +221,7 @@ private:
     bool m_AllowSidebarToggle; // Chronoshift option.
     bool m_CounterstrikeEnabled; // Chronoshift option.
     bool m_AftermathEnabled; // Chronoshift option.
+    bool m_ExpansionOptionsPresent; // Chronoshift option.
 #endif
     KeyNumType m_KeyForceMove1;
     KeyNumType m_KeyForceMove2;

--- a/src/hooker/setuphooks.cpp
+++ b/src/hooker/setuphooks.cpp
@@ -45,6 +45,7 @@
 #include "drive.h"
 #include "droplist.h"
 #include "excepthandler.h"
+#include "expansion.h"
 #include "facing.h"
 #include "factory.h"
 #include "fading.h"
@@ -689,6 +690,10 @@ void Setup_Hooks()
     Hook_Function(0x0053CD80, *ScenarioClass::Hook_Set_Scenario_Name2);
     Hook_Function(0x00539BF8, *ScenarioClass::Do_BW_Fade);
     Hook_Function(0x00539C40, *ScenarioClass::Do_Fade_AI);
+
+    // expansion.h
+    Hook_Function(0x004ABF88, Is_Counterstrike_Installed);
+    Hook_Function(0x004AC024, Is_Aftermath_Installed);
 
     // mission.h
     Hook_Function(0x00502C70, *MissionClass::Assign_Mission);


### PR DESCRIPTION
Fixes reading the registry for expansion install status and makes existence of [Expansions] section in chronoshift.ini override the registry all together.